### PR TITLE
Include the service provider in the callback to retrieve storage configuration

### DIFF
--- a/Solutions/Corvus.Tenancy.Specs/Bindings/TenancyContainerBindings.cs
+++ b/Solutions/Corvus.Tenancy.Specs/Bindings/TenancyContainerBindings.cs
@@ -48,7 +48,7 @@ namespace Corvus.Tenancy.Specs.Bindings
 
                     if (featureContext.FeatureInfo.Tags.Any(t => t == "withBlobStorageTenantProvider"))
                     {
-                        serviceCollection.AddTenantProviderBlobStore(() =>
+                        serviceCollection.AddTenantProviderBlobStore(_ =>
                         {
                             var blobStorageConfiguration = new BlobStorageConfiguration();
                             config.Bind("TENANCYBLOBSTORAGECONFIGURATIONOPTIONS", blobStorageConfiguration);

--- a/Solutions/Corvus.Tenancy.Storage.Azure.Blob/Microsoft/Extensions/DependencyInjection/TenantProviderBlobStoreServiceCollectionExtensions.cs
+++ b/Solutions/Corvus.Tenancy.Storage.Azure.Blob/Microsoft/Extensions/DependencyInjection/TenantProviderBlobStoreServiceCollectionExtensions.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The modified service collection.</returns>
         public static IServiceCollection AddTenantProviderBlobStore(
             this IServiceCollection services,
-            Func<BlobStorageConfiguration> getRootTenantStorageConfiguration)
+            Func<IServiceProvider, BlobStorageConfiguration> getRootTenantStorageConfiguration)
         {
             if (services.Any(s => typeof(ITenantProvider).IsAssignableFrom(s.ServiceType)))
             {
@@ -37,7 +37,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddRootTenant();
             services.AddSingleton<ITenantProvider>(sp =>
             {
-                BlobStorageConfiguration rootTenantStorageConfig = getRootTenantStorageConfiguration();
+                BlobStorageConfiguration rootTenantStorageConfig = getRootTenantStorageConfiguration(sp);
                 RootTenant rootTenant = sp.GetRequiredService<RootTenant>();
 
                 rootTenant.SetBlobStorageConfiguration(TenantProviderBlobStore.ContainerDefinition, rootTenantStorageConfig);


### PR DESCRIPTION
Functions apps need to be supplied with the current `IServiceProvider` in the callback to retrieve configuration so that they can access the current `IConfiguration` instance.