### PR TITLE
Add a name to the Root tenant

### DIFF
--- a/Solutions/Corvus.Tenancy.Abstractions/Corvus/Tenancy/RootTenant.cs
+++ b/Solutions/Corvus.Tenancy.Abstractions/Corvus/Tenancy/RootTenant.cs
@@ -13,6 +13,14 @@ namespace Corvus.Tenancy
     public class RootTenant : Tenant
     {
         /// <summary>
+        /// The name of the root tenant.
+        /// </summary>
+        /// <remarks>
+        /// This should not be used to check if an <see cref="ITenant"/> is the Root tenant - compare using <see cref="RootTenantId"/>.
+        /// </remarks>
+        public const string RootTenantName = "Root";
+
+        /// <summary>
         /// The root tenant ID.
         /// </summary>
         /// <remarks>
@@ -28,6 +36,7 @@ namespace Corvus.Tenancy
             : base(serializerSettingsProvider)
         {
             this.Id = RootTenantId;
+            this.Name = RootTenantName;
         }
     }
 }


### PR DESCRIPTION
When I added the `Name` property to `ITenant` and `Tenant`, I did so in a way that it did not need to be set as soon as the `Tenant` was created, I copied the same pattern used for the existing `Id` property that does not allow the value to be set as null, and throws an `InvalidOperationException` if the property is accessed before it's set.

I believe the `Id` property was implemented this way because internally, instances of `Tenant` are created using the DI container so that they can be supplied with an `IJsonSerializerSettingsProvider`, which means that it's not possible to supply `Id` (and now `Name`) via constructor parameters.

However, I didn't add code to set the `Name` property on the Root tenant, which means that if you end up with an `ITenant` that's the root and then try and access it's `Name` property, you get an exception. This makes the `RootTenant` behave differently to other `ITenant` implementations in the sense that under normal usage, you would not expect accessing the `Name` property to throw an exception (it's not possible to persist a `Tenant` without a `Name` because the serialization process would attempt to read the `Name` and the exception would be thrown, so it's generally safe to expect `Name` to be set).

So, this PR sets the name of the `RootTenant` so it can safely be treated the same way as other tenants where necessary.