### PR TITLE
Use new IPropertyBag abstraction

### DIFF
--- a/Solutions/Corvus.Azure.Cosmos.Tenancy/Corvus.Azure.Cosmos.Tenancy.csproj
+++ b/Solutions/Corvus.Azure.Cosmos.Tenancy/Corvus.Azure.Cosmos.Tenancy.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="$(EndjinProjectPropsPath)" />
+
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Nullable>enable</Nullable>
-    <RootNamespace />
   </PropertyGroup>
 
   <PropertyGroup>
@@ -14,9 +15,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Corvus.ContentHandling.Json" Version="0.12.0" />
     <PackageReference Include="Corvus.Extensions.CosmosClient" Version="0.6.0" />
-    <PackageReference Include="Endjin.RecommendedPractices" Version="0.1.0">
+    <PackageReference Include="Endjin.RecommendedPractices" Version="0.2.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Solutions/Corvus.Azure.Cosmos.Tenancy/Corvus.Azure.Cosmos.Tenancy.csproj
+++ b/Solutions/Corvus.Azure.Cosmos.Tenancy/Corvus.Azure.Cosmos.Tenancy.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="$(EndjinProjectPropsPath)" />
+  <Import Project="$(EndjinProjectPropsPath)" Condition="$(EndjinProjectPropsPath) != ''" />
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Corvus.Extensions.CosmosClient" Version="0.6.0" />
-    <PackageReference Include="Endjin.RecommendedPractices" Version="0.2.1">
+    <PackageReference Include="Endjin.RecommendedPractices" Version="0.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Solutions/Corvus.Azure.Cosmos.Tenancy/Corvus/Azure/Cosmos/Tenancy/CosmosStorageTenantExtensions.cs
+++ b/Solutions/Corvus.Azure.Cosmos.Tenancy/Corvus/Azure/Cosmos/Tenancy/CosmosStorageTenantExtensions.cs
@@ -5,6 +5,9 @@
 namespace Corvus.Azure.Cosmos.Tenancy
 {
     using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Corvus.Extensions.Json;
     using Corvus.Tenancy;
 
     /// <summary>
@@ -31,7 +34,7 @@ namespace Corvus.Azure.Cosmos.Tenancy
             }
 
             // First, try the configuration specific to this instance
-            if (tenant.Properties.TryGet(GetConfigurationKey(definition), out CosmosConfiguration configuration))
+            if (tenant.Properties.TryGetNonNullValue(GetConfigurationKey(definition), out CosmosConfiguration? configuration))
             {
                 return configuration;
             }
@@ -40,16 +43,24 @@ namespace Corvus.Azure.Cosmos.Tenancy
         }
 
         /// <summary>
-        /// Sets the Cosmos configuration for the specified container for the tenant.
+        /// Creates Cosmos container configuration properties suitable for passing to
+        /// <see cref="ITenantStore.UpdateTenantAsync(string, IEnumerable{KeyValuePair{string, object}}?, IEnumerable{string}?)"/>.
         /// </summary>
-        /// <param name="tenant">The tenant for which to set the configuration.</param>
+        /// <param name="values">Existing configuration values to which to append these.</param>
         /// <param name="definition">The definition of the Cosmos container for which to set the configuration.</param>
         /// <param name="configuration">The configuration to set.</param>
-        public static void SetCosmosConfiguration(this ITenant tenant, CosmosContainerDefinition definition, CosmosConfiguration configuration)
+        /// <returns>
+        /// Properties pass to
+        /// <see cref="ITenantStore.UpdateTenantAsync(string, IEnumerable{KeyValuePair{string, object}}?, IEnumerable{string}?)"/>.
+        /// </returns>
+        public static IEnumerable<KeyValuePair<string, object>> AddCosmosConfiguration(
+            this IEnumerable<KeyValuePair<string, object>> values,
+            CosmosContainerDefinition definition,
+            CosmosConfiguration configuration)
         {
-            if (tenant is null)
+            if (values is null)
             {
-                throw new ArgumentNullException(nameof(tenant));
+                throw new ArgumentNullException(nameof(values));
             }
 
             if (definition is null)
@@ -57,7 +68,12 @@ namespace Corvus.Azure.Cosmos.Tenancy
                 throw new ArgumentNullException(nameof(definition));
             }
 
-            tenant.Properties.Set(GetConfigurationKey(definition), configuration);
+            if (configuration is null)
+            {
+                throw new ArgumentNullException(nameof(configuration));
+            }
+
+            return values.Append(new KeyValuePair<string, object>(GetConfigurationKey(definition), configuration));
         }
 
         private static string GetConfigurationKey(CosmosContainerDefinition definition)

--- a/Solutions/Corvus.Azure.Cosmos.Tenancy/Corvus/Azure/Cosmos/Tenancy/CosmosStorageTenantExtensions.cs
+++ b/Solutions/Corvus.Azure.Cosmos.Tenancy/Corvus/Azure/Cosmos/Tenancy/CosmosStorageTenantExtensions.cs
@@ -44,14 +44,14 @@ namespace Corvus.Azure.Cosmos.Tenancy
 
         /// <summary>
         /// Creates Cosmos container configuration properties suitable for passing to
-        /// <see cref="ITenantStore.UpdateTenantAsync(string, IEnumerable{KeyValuePair{string, object}}?, IEnumerable{string}?)"/>.
+        /// <see cref="ITenantStore.UpdateTenantAsync(string, string?, IEnumerable{KeyValuePair{string, object}}?, IEnumerable{string}?)"/>.
         /// </summary>
         /// <param name="values">Existing configuration values to which to append these.</param>
         /// <param name="definition">The definition of the Cosmos container for which to set the configuration.</param>
         /// <param name="configuration">The configuration to set.</param>
         /// <returns>
         /// Properties pass to
-        /// <see cref="ITenantStore.UpdateTenantAsync(string, IEnumerable{KeyValuePair{string, object}}?, IEnumerable{string}?)"/>.
+        /// <see cref="ITenantStore.UpdateTenantAsync(string, string?, IEnumerable{KeyValuePair{string, object}}?, IEnumerable{string}?)"/>.
         /// </returns>
         public static IEnumerable<KeyValuePair<string, object>> AddCosmosConfiguration(
             this IEnumerable<KeyValuePair<string, object>> values,

--- a/Solutions/Corvus.Azure.Cosmos.Tenancy/Corvus/Azure/Cosmos/Tenancy/CosmosStorageTenantExtensions.cs
+++ b/Solutions/Corvus.Azure.Cosmos.Tenancy/Corvus/Azure/Cosmos/Tenancy/CosmosStorageTenantExtensions.cs
@@ -7,7 +7,6 @@ namespace Corvus.Azure.Cosmos.Tenancy
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using Corvus.Extensions.Json;
     using Corvus.Tenancy;
 
     /// <summary>
@@ -34,7 +33,7 @@ namespace Corvus.Azure.Cosmos.Tenancy
             }
 
             // First, try the configuration specific to this instance
-            if (tenant.Properties.TryGetNonNullValue(GetConfigurationKey(definition), out CosmosConfiguration? configuration))
+            if (tenant.Properties.TryGet(GetConfigurationKey(definition), out CosmosConfiguration? configuration))
             {
                 return configuration;
             }

--- a/Solutions/Corvus.Azure.Cosmos.Tenancy/Corvus/Azure/Cosmos/Tenancy/ITenantCosmosContainerFactory.cs
+++ b/Solutions/Corvus.Azure.Cosmos.Tenancy/Corvus/Azure/Cosmos/Tenancy/ITenantCosmosContainerFactory.cs
@@ -16,7 +16,7 @@ namespace Corvus.Azure.Cosmos.Tenancy
     /// <para>
     /// You use this type to get an instance of an <see cref="Container"/> for a specific
     /// <see cref="ITenant"/>. It uses a KeyVault to get the storage account key for the tenant, and the
-    /// configuration comes from the tenant via <see cref="CosmosStorageTenantExtensions.SetCosmosConfiguration(ITenant, CosmosContainerDefinition, CosmosConfiguration)"/>.
+    /// configuration comes from the tenant via <see cref="CosmosStorageTenantExtensions.AddCosmosConfiguration(System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair{string, object}}, CosmosContainerDefinition, CosmosConfiguration)"/>.
     /// </para>
     /// <para>
     /// To configure a simple single-tenanted solution, which can ultimately be extended to multitenancy, the easiest route is to configure a configuration-based account key

--- a/Solutions/Corvus.Azure.Cosmos.Tenancy/Corvus/Azure/Cosmos/Tenancy/Internal/TenantCosmosContainerFactory.cs
+++ b/Solutions/Corvus.Azure.Cosmos.Tenancy/Corvus/Azure/Cosmos/Tenancy/Internal/TenantCosmosContainerFactory.cs
@@ -22,7 +22,7 @@ namespace Corvus.Azure.Cosmos.Tenancy.Internal
     /// <para>
     /// You use this type to get an instance of an <see cref="Container"/> for a specific
     /// <see cref="ITenant"/>. It uses a KeyVault to get the storage account key for the tenant, and the
-    /// configuration comes from the tenant via <see cref="CosmosStorageTenantExtensions.SetCosmosConfiguration(ITenant, CosmosContainerDefinition, CosmosConfiguration)"/>.
+    /// configuration comes from the tenant via <see cref="CosmosStorageTenantExtensions.AddCosmosConfiguration(System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair{string, object}}, CosmosContainerDefinition, CosmosConfiguration)"/>.
     /// </para>
     /// <para>
     /// To configure a simple single-tenanted solution, which can ultimately be extended to multitenancy, the easiest route is to configure a configuration-based account key
@@ -58,7 +58,7 @@ namespace Corvus.Azure.Cosmos.Tenancy.Internal
     /// implement key rotation.
     /// </para>
     /// </remarks>
-    public class TenantCosmosContainerFactory : ITenantCosmosContainerFactory
+    internal class TenantCosmosContainerFactory : ITenantCosmosContainerFactory
     {
         private const string DevelopmentStorageConnectionString = "AccountEndpoint=https://localhost:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
 

--- a/Solutions/Corvus.Azure.Gremlin.Tenancy/Corvus.Azure.Gremlin.Tenancy.csproj
+++ b/Solutions/Corvus.Azure.Gremlin.Tenancy/Corvus.Azure.Gremlin.Tenancy.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="$(EndjinProjectPropsPath)" />
+  <Import Project="$(EndjinProjectPropsPath)" Condition="$(EndjinProjectPropsPath) != ''" />
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Endjin.RecommendedPractices" Version="0.2.1">
+    <PackageReference Include="Endjin.RecommendedPractices" Version="0.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Solutions/Corvus.Azure.Gremlin.Tenancy/Corvus.Azure.Gremlin.Tenancy.csproj
+++ b/Solutions/Corvus.Azure.Gremlin.Tenancy/Corvus.Azure.Gremlin.Tenancy.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="$(EndjinProjectPropsPath)" />
+
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <RootNamespace />
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
@@ -14,8 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Corvus.ContentHandling.Json" Version="0.12.0" />
-    <PackageReference Include="Endjin.RecommendedPractices" Version="0.1.0">
+    <PackageReference Include="Endjin.RecommendedPractices" Version="0.2.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Solutions/Corvus.Azure.Gremlin.Tenancy/Corvus/Azure/GremlinExtensions/Tenancy/GremlinStorageTenantExtensions.cs
+++ b/Solutions/Corvus.Azure.Gremlin.Tenancy/Corvus/Azure/GremlinExtensions/Tenancy/GremlinStorageTenantExtensions.cs
@@ -7,7 +7,6 @@ namespace Corvus.Azure.GremlinExtensions.Tenancy
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using Corvus.Extensions.Json;
     using Corvus.Tenancy;
 
     /// <summary>
@@ -34,7 +33,7 @@ namespace Corvus.Azure.GremlinExtensions.Tenancy
             }
 
             // First, try the configuration specific to this instance
-            if (tenant.Properties.TryGetNonNullValue(GetConfigurationKey(definition), out GremlinConfiguration? configuration))
+            if (tenant.Properties.TryGet(GetConfigurationKey(definition), out GremlinConfiguration? configuration))
             {
                 return configuration;
             }

--- a/Solutions/Corvus.Azure.Gremlin.Tenancy/Corvus/Azure/GremlinExtensions/Tenancy/GremlinStorageTenantExtensions.cs
+++ b/Solutions/Corvus.Azure.Gremlin.Tenancy/Corvus/Azure/GremlinExtensions/Tenancy/GremlinStorageTenantExtensions.cs
@@ -44,14 +44,14 @@ namespace Corvus.Azure.GremlinExtensions.Tenancy
 
         /// <summary>
         /// Creates Gremlin configuration for the specified container suitable for passing to
-        /// <see cref="ITenantStore.UpdateTenantAsync(string, IEnumerable{KeyValuePair{string, object}}?, IEnumerable{string}?)"/>.
+        /// <see cref="ITenantStore.UpdateTenantAsync(string, string?, IEnumerable{KeyValuePair{string, object}}?, IEnumerable{string}?)"/>.
         /// </summary>
         /// <param name="values">Existing configuration values to which to append these.</param>
         /// <param name="definition">The definition of the Gremlin container for which to set the configuration.</param>
         /// <param name="configuration">The configuration to set.</param>
         /// <returns>
         /// Properties to pass to
-        /// <see cref="ITenantStore.UpdateTenantAsync(string, IEnumerable{KeyValuePair{string, object}}?, IEnumerable{string}?)"/>.
+        /// <see cref="ITenantStore.UpdateTenantAsync(string, string?, IEnumerable{KeyValuePair{string, object}}?, IEnumerable{string}?)"/>.
         /// </returns>
         public static IEnumerable<KeyValuePair<string, object>> AddGremlinConfiguration(
             this IEnumerable<KeyValuePair<string, object>> values,

--- a/Solutions/Corvus.Azure.Gremlin.Tenancy/Corvus/Azure/GremlinExtensions/Tenancy/ITenantGremlinContainerFactory.cs
+++ b/Solutions/Corvus.Azure.Gremlin.Tenancy/Corvus/Azure/GremlinExtensions/Tenancy/ITenantGremlinContainerFactory.cs
@@ -16,7 +16,7 @@ namespace Corvus.Azure.GremlinExtensions.Tenancy
     /// <para>
     /// You use this type to get an instance of an <see cref="GremlinClient"/> for a specific
     /// <see cref="ITenant"/>. It uses a KeyVault to get the storage account key for the tenant, and the
-    /// configuration comes from the tenant via <see cref="GremlinStorageTenantExtensions.SetGremlinConfiguration(ITenant, GremlinContainerDefinition, GremlinConfiguration)"/>.
+    /// configuration comes from the tenant via <see cref="GremlinStorageTenantExtensions.AddGremlinConfiguration(System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair{string, object}}, GremlinContainerDefinition, GremlinConfiguration)"/>.
     /// </para>
     /// <para>
     /// To configure a simple single-tenanted solution, which can ultimately be extended to multitenancy, the easiest route is to configure a configuration-based account key

--- a/Solutions/Corvus.Azure.Gremlin.Tenancy/Corvus/Azure/GremlinExtensions/Tenancy/Internal/TenantGremlinContainerFactory.cs
+++ b/Solutions/Corvus.Azure.Gremlin.Tenancy/Corvus/Azure/GremlinExtensions/Tenancy/Internal/TenantGremlinContainerFactory.cs
@@ -20,7 +20,7 @@ namespace Corvus.Azure.GremlinExtensions.Tenancy.Internal
     /// <para>
     /// You use this type to get an instance of an <see cref="GremlinClient"/> for a specific
     /// <see cref="ITenant"/>. It uses a KeyVault to get the storage account key for the tenant, and the
-    /// configuration comes from the tenant via <see cref="GremlinStorageTenantExtensions.SetGremlinConfiguration(ITenant, GremlinContainerDefinition, GremlinConfiguration)"/>.
+    /// configuration comes from the tenant via <see cref="GremlinStorageTenantExtensions.AddGremlinConfiguration(System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair{string, object}}, GremlinContainerDefinition, GremlinConfiguration)"/>.
     /// </para>
     /// <para>
     /// To configure a simple single-tenanted solution, which can ultimately be extended to multitenancy, the easiest route is to configure a configuration-based account key
@@ -61,10 +61,10 @@ namespace Corvus.Azure.GremlinExtensions.Tenancy.Internal
     /// implement key rotation.
     /// </para>
     /// </remarks>
-    public class TenantGremlinContainerFactory : ITenantGremlinContainerFactory
+    internal class TenantGremlinContainerFactory : ITenantGremlinContainerFactory
     {
-        private const string DevelopmentHostName = "https://localhost";
-        private const int DevelopmentPort = 8081;
+        private const string DevelopmentHostName = "localhost";
+        private const int DevelopmentPort = 8901;
         private const string DevelopmentAuthKey = "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
 
         private readonly ConcurrentDictionary<object, Task<GremlinServer>> servers = new ConcurrentDictionary<object, Task<GremlinServer>>();
@@ -219,7 +219,7 @@ namespace Corvus.Azure.GremlinExtensions.Tenancy.Internal
             string username = BuildTenantSpecificUserName(databaseName, containerName);
             if (string.IsNullOrEmpty(configuration.HostName) || configuration.HostName == DevelopmentHostName)
             {
-                return new GremlinServer(DevelopmentHostName, DevelopmentPort, true, username, DevelopmentAuthKey);
+                return new GremlinServer(DevelopmentHostName, DevelopmentPort, false, username, DevelopmentAuthKey);
             }
             else
             {

--- a/Solutions/Corvus.Azure.Storage.Tenancy/Corvus.Azure.Storage.Tenancy.csproj
+++ b/Solutions/Corvus.Azure.Storage.Tenancy/Corvus.Azure.Storage.Tenancy.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="$(EndjinProjectPropsPath)" />
+  <Import Project="$(EndjinProjectPropsPath)" Condition="$(EndjinProjectPropsPath) != ''" />
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Endjin.RecommendedPractices" Version="0.2.1">
+    <PackageReference Include="Endjin.RecommendedPractices" Version="0.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Solutions/Corvus.Azure.Storage.Tenancy/Corvus.Azure.Storage.Tenancy.csproj
+++ b/Solutions/Corvus.Azure.Storage.Tenancy/Corvus.Azure.Storage.Tenancy.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="$(EndjinProjectPropsPath)" />
+
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <RootNamespace />
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
@@ -14,8 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Corvus.ContentHandling.Json" Version="0.12.0" />
-    <PackageReference Include="Endjin.RecommendedPractices" Version="0.1.0">
+    <PackageReference Include="Endjin.RecommendedPractices" Version="0.2.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Solutions/Corvus.Azure.Storage.Tenancy/Corvus/Azure/Storage/Tenancy/BlobStorageTenantExtensions.cs
+++ b/Solutions/Corvus.Azure.Storage.Tenancy/Corvus/Azure/Storage/Tenancy/BlobStorageTenantExtensions.cs
@@ -7,7 +7,6 @@ namespace Corvus.Azure.Storage.Tenancy
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using Corvus.Extensions.Json;
     using Corvus.Tenancy;
     using Newtonsoft.Json.Linq;
 
@@ -56,7 +55,7 @@ namespace Corvus.Azure.Storage.Tenancy
                 throw new ArgumentNullException(nameof(definition));
             }
 
-            if (tenant.Properties.TryGetNonNullValue(GetConfigurationKey(definition), out BlobStorageConfiguration? configuration))
+            if (tenant.Properties.TryGet(GetConfigurationKey(definition), out BlobStorageConfiguration? configuration))
             {
                 return configuration;
             }

--- a/Solutions/Corvus.Azure.Storage.Tenancy/Corvus/Azure/Storage/Tenancy/BlobStorageTenantExtensions.cs
+++ b/Solutions/Corvus.Azure.Storage.Tenancy/Corvus/Azure/Storage/Tenancy/BlobStorageTenantExtensions.cs
@@ -66,14 +66,14 @@ namespace Corvus.Azure.Storage.Tenancy
 
         /// <summary>
         /// Creates repository configuration properties suitable for passing to
-        /// <see cref="ITenantStore.UpdateTenantAsync(string, IEnumerable{KeyValuePair{string, object}}?, IEnumerable{string}?)"/>.
+        /// <see cref="ITenantStore.UpdateTenantAsync(string, string?, IEnumerable{KeyValuePair{string, object}}?, IEnumerable{string}?)"/>.
         /// </summary>
         /// <param name="values">Existing configuration values to which to append these.</param>
         /// <param name="definition">The definition of the repository for which to set the configuration.</param>
         /// <param name="configuration">The configuration to set.</param>
         /// <returns>
         /// Properties to pass to
-        /// <see cref="ITenantStore.UpdateTenantAsync(string, IEnumerable{KeyValuePair{string, object}}?, IEnumerable{string}?)"/>.
+        /// <see cref="ITenantStore.UpdateTenantAsync(string, string?, IEnumerable{KeyValuePair{string, object}}?, IEnumerable{string}?)"/>.
         /// </returns>
         public static IEnumerable<KeyValuePair<string, object>> AddBlobStorageConfiguration(
             this IEnumerable<KeyValuePair<string, object>> values,

--- a/Solutions/Corvus.Azure.Storage.Tenancy/Corvus/Azure/Storage/Tenancy/ITenantCloudBlobContainerFactory.cs
+++ b/Solutions/Corvus.Azure.Storage.Tenancy/Corvus/Azure/Storage/Tenancy/ITenantCloudBlobContainerFactory.cs
@@ -15,7 +15,7 @@ namespace Corvus.Azure.Storage.Tenancy
     /// <para>
     /// You use this type to get an instance of an <see cref="CloudBlobContainer"/> for a specific
     /// <see cref="ITenant"/>. It uses a KeyVault to get the storage account key for the tenant, and the
-    /// configuration comes from the tenant via <see cref="BlobStorageTenantExtensions.SetBlobStorageConfiguration(ITenant, BlobStorageContainerDefinition, BlobStorageConfiguration)"/>.
+    /// configuration comes from the tenant via <see cref="BlobStorageTenantExtensions.AddBlobStorageConfiguration(System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair{string, object}}, BlobStorageContainerDefinition, BlobStorageConfiguration)"/>.
     /// </para>
     /// <para>
     /// To configure a simple single-tenanted solution, which can ultimately be extended to multitenancy, the easiest route is to configure a configuration-based account key

--- a/Solutions/Corvus.Azure.Storage.Tenancy/Corvus/Azure/Storage/Tenancy/Internal/TenantCloudBlobContainerFactory.cs
+++ b/Solutions/Corvus.Azure.Storage.Tenancy/Corvus/Azure/Storage/Tenancy/Internal/TenantCloudBlobContainerFactory.cs
@@ -23,7 +23,7 @@ namespace Corvus.Azure.Storage.Tenancy
     /// <para>
     /// You use this type to get an instance of an <see cref="CloudBlobContainer"/> for a specific
     /// <see cref="ITenant"/>. It uses a KeyVault to get the storage account key for the tenant, and the
-    /// configuration comes from the tenant the <see cref="BlobStorageTenantExtensions.SetBlobStorageConfiguration(ITenant, BlobStorageContainerDefinition, BlobStorageConfiguration)"/>.
+    /// configuration comes from the tenant the <see cref="BlobStorageTenantExtensions.AddBlobStorageConfiguration(System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair{string, object}}, BlobStorageContainerDefinition, BlobStorageConfiguration)"/>.
     /// </para>
     /// <para>
     /// To configure a simple single-tenanted solution, which can ultimately be extended to multitenancy, the easiest route is to configure a configuration-based account key
@@ -64,7 +64,7 @@ namespace Corvus.Azure.Storage.Tenancy
     /// implement key rotation.
     /// </para>
     /// </remarks>
-    public class TenantCloudBlobContainerFactory : ITenantCloudBlobContainerFactory
+    internal class TenantCloudBlobContainerFactory : ITenantCloudBlobContainerFactory
     {
         private const string DevelopmentStorageConnectionString = "UseDevelopmentStorage=true";
 

--- a/Solutions/Corvus.Sql.Tenancy/Corvus.Sql.Tenancy.csproj
+++ b/Solutions/Corvus.Sql.Tenancy/Corvus.Sql.Tenancy.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="$(EndjinProjectPropsPath)" />
+  <Import Project="$(EndjinProjectPropsPath)" Condition="$(EndjinProjectPropsPath) != ''" />
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Endjin.RecommendedPractices" Version="0.2.1">
+    <PackageReference Include="Endjin.RecommendedPractices" Version="0.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Solutions/Corvus.Sql.Tenancy/Corvus.Sql.Tenancy.csproj
+++ b/Solutions/Corvus.Sql.Tenancy/Corvus.Sql.Tenancy.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="$(EndjinProjectPropsPath)" />
+
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <RootNamespace />
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
@@ -14,8 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Corvus.ContentHandling.Json" Version="0.12.0" />
-    <PackageReference Include="Endjin.RecommendedPractices" Version="0.1.0">
+    <PackageReference Include="Endjin.RecommendedPractices" Version="0.2.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Solutions/Corvus.Sql.Tenancy/Corvus/Sql/Tenancy/ITenantSqlConnectionFactory.cs
+++ b/Solutions/Corvus.Sql.Tenancy/Corvus/Sql/Tenancy/ITenantSqlConnectionFactory.cs
@@ -16,7 +16,7 @@ namespace Corvus.Sql.Tenancy
     /// <para>
     /// You use this type to get an instance of an <see cref="SqlConnection"/> for a specific
     /// <see cref="ITenant"/>. It typically uses a KeyVault to get the SQL Server connection string for the tenant, and the
-    /// configuration comes from the tenant via <see cref="SqlStorageTenantExtensions.SetSqlConfiguration(ITenant, SqlConnectionDefinition, SqlConfiguration)"/>.
+    /// configuration comes from the tenant via <see cref="SqlStorageTenantExtensions.AddSqlConfiguration(System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair{string, object}}, SqlConnectionDefinition, SqlConfiguration)"/>.
     /// </para>
     /// <para>
     /// To configure a simple single-tenanted solution, which can ultimately be extended to multitenancy, the easiest route is to configure a configuration-based account key

--- a/Solutions/Corvus.Sql.Tenancy/Corvus/Sql/Tenancy/Internal/TenantSqlConnectionFactory.cs
+++ b/Solutions/Corvus.Sql.Tenancy/Corvus/Sql/Tenancy/Internal/TenantSqlConnectionFactory.cs
@@ -23,7 +23,7 @@ namespace Corvus.Sql.Tenancy.Internal
     /// <para>
     /// You use this type to get an instance of a <see cref="SqlConnection"/> for a specific
     /// <see cref="ITenant"/>. It uses a KeyVault to get the connection string for the tenant, and the
-    /// configuration comes from the tenant via <see cref="SqlStorageTenantExtensions.SetSqlConfiguration(ITenant, SqlConnectionDefinition, SqlConfiguration)"/>.
+    /// configuration comes from the tenant via <see cref="SqlStorageTenantExtensions.AddSqlConfiguration(System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair{string, object}}, SqlConnectionDefinition, SqlConfiguration)"/>.
     /// </para>
     /// <para>
     /// To configure a simple single-tenanted solution, which can ultimately be extended to multitenancy, the easiest route is to configure a configuration-based account key
@@ -59,7 +59,7 @@ namespace Corvus.Sql.Tenancy.Internal
     /// implement key rotation.
     /// </para>
     /// </remarks>
-    public class TenantSqlConnectionFactory : ITenantSqlConnectionFactory
+    internal class TenantSqlConnectionFactory : ITenantSqlConnectionFactory
     {
         private const string DevelopmentStorageConnectionString = "Server=(localdb)\\mssqllocaldb;Database=testtenant;Trusted_Connection=True;MultipleActiveResultSets=true";
 

--- a/Solutions/Corvus.Sql.Tenancy/Corvus/Sql/Tenancy/SqlStorageTenantExtensions.cs
+++ b/Solutions/Corvus.Sql.Tenancy/Corvus/Sql/Tenancy/SqlStorageTenantExtensions.cs
@@ -7,7 +7,6 @@ namespace Corvus.Sql.Tenancy
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using Corvus.Extensions.Json;
     using Corvus.Tenancy;
 
     /// <summary>
@@ -34,7 +33,7 @@ namespace Corvus.Sql.Tenancy
             }
 
             // First, try the configuration specific to this instance
-            if (tenant.Properties.TryGetNonNullValue(GetConfigurationKey(definition), out SqlConfiguration? configuration))
+            if (tenant.Properties.TryGet(GetConfigurationKey(definition), out SqlConfiguration? configuration))
             {
                 return configuration;
             }

--- a/Solutions/Corvus.Sql.Tenancy/Corvus/Sql/Tenancy/SqlStorageTenantExtensions.cs
+++ b/Solutions/Corvus.Sql.Tenancy/Corvus/Sql/Tenancy/SqlStorageTenantExtensions.cs
@@ -5,6 +5,9 @@
 namespace Corvus.Sql.Tenancy
 {
     using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Corvus.Extensions.Json;
     using Corvus.Tenancy;
 
     /// <summary>
@@ -31,7 +34,7 @@ namespace Corvus.Sql.Tenancy
             }
 
             // First, try the configuration specific to this instance
-            if (tenant.Properties.TryGet(GetConfigurationKey(definition), out SqlConfiguration configuration))
+            if (tenant.Properties.TryGetNonNullValue(GetConfigurationKey(definition), out SqlConfiguration? configuration))
             {
                 return configuration;
             }
@@ -40,16 +43,24 @@ namespace Corvus.Sql.Tenancy
         }
 
         /// <summary>
-        /// Sets the Sql configuration for the specified container for the tenant.
+        /// Creates Sql configuration properties for the specified container suitable for passing to
+        /// <see cref="ITenantStore.UpdateTenantAsync(string, IEnumerable{KeyValuePair{string, object}}?, IEnumerable{string}?)"/>.
         /// </summary>
-        /// <param name="tenant">The tenant for which to set the configuration.</param>
+        /// <param name="values">Existing configuration values to which to append these.</param>
         /// <param name="definition">The definition of the Sql container for which to set the configuration.</param>
         /// <param name="configuration">The configuration to set.</param>
-        public static void SetSqlConfiguration(this ITenant tenant, SqlConnectionDefinition definition, SqlConfiguration configuration)
+        /// <returns>
+        /// Properties to pass to
+        /// <see cref="ITenantStore.UpdateTenantAsync(string, IEnumerable{KeyValuePair{string, object}}?, IEnumerable{string}?)"/>.
+        /// </returns>
+        public static IEnumerable<KeyValuePair<string, object>> AddSqlConfiguration(
+            this IEnumerable<KeyValuePair<string, object>> values,
+            SqlConnectionDefinition definition,
+            SqlConfiguration configuration)
         {
-            if (tenant is null)
+            if (values is null)
             {
-                throw new ArgumentNullException(nameof(tenant));
+                throw new ArgumentNullException(nameof(values));
             }
 
             if (definition is null)
@@ -57,7 +68,12 @@ namespace Corvus.Sql.Tenancy
                 throw new ArgumentNullException(nameof(definition));
             }
 
-            tenant.Properties.Set(GetConfigurationKey(definition), configuration);
+            if (configuration is null)
+            {
+                throw new ArgumentNullException(nameof(configuration));
+            }
+
+            return values.Append(new KeyValuePair<string, object>(GetConfigurationKey(definition), configuration));
         }
 
         private static string GetConfigurationKey(SqlConnectionDefinition definition)

--- a/Solutions/Corvus.Sql.Tenancy/Corvus/Sql/Tenancy/SqlStorageTenantExtensions.cs
+++ b/Solutions/Corvus.Sql.Tenancy/Corvus/Sql/Tenancy/SqlStorageTenantExtensions.cs
@@ -44,14 +44,14 @@ namespace Corvus.Sql.Tenancy
 
         /// <summary>
         /// Creates Sql configuration properties for the specified container suitable for passing to
-        /// <see cref="ITenantStore.UpdateTenantAsync(string, IEnumerable{KeyValuePair{string, object}}?, IEnumerable{string}?)"/>.
+        /// <see cref="ITenantStore.UpdateTenantAsync(string, string?, IEnumerable{KeyValuePair{string, object}}?, IEnumerable{string}?)"/>.
         /// </summary>
         /// <param name="values">Existing configuration values to which to append these.</param>
         /// <param name="definition">The definition of the Sql container for which to set the configuration.</param>
         /// <param name="configuration">The configuration to set.</param>
         /// <returns>
         /// Properties to pass to
-        /// <see cref="ITenantStore.UpdateTenantAsync(string, IEnumerable{KeyValuePair{string, object}}?, IEnumerable{string}?)"/>.
+        /// <see cref="ITenantStore.UpdateTenantAsync(string, string?, IEnumerable{KeyValuePair{string, object}}?, IEnumerable{string}?)"/>.
         /// </returns>
         public static IEnumerable<KeyValuePair<string, object>> AddSqlConfiguration(
             this IEnumerable<KeyValuePair<string, object>> values,

--- a/Solutions/Corvus.Tenancy.Abstractions/Corvus.Tenancy.Abstractions.csproj
+++ b/Solutions/Corvus.Tenancy.Abstractions/Corvus.Tenancy.Abstractions.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="$(EndjinProjectPropsPath)" />
+  <Import Project="$(EndjinProjectPropsPath)" Condition="$(EndjinProjectPropsPath) != ''" />
   
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -19,7 +19,7 @@
     <PackageReference Include="Corvus.Extensions" Version="0.8.0" />
     <!-- TODO: we should remove this ref once we're done because it should come from Corvus.ContentHandling.Json -->
     <PackageReference Include="Corvus.Extensions.Newtonsoft.Json" Version="0.10.0-PullRequest0087.18" />
-    <PackageReference Include="Endjin.RecommendedPractices" Version="0.2.1">
+    <PackageReference Include="Endjin.RecommendedPractices" Version="0.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Solutions/Corvus.Tenancy.Abstractions/Corvus.Tenancy.Abstractions.csproj
+++ b/Solutions/Corvus.Tenancy.Abstractions/Corvus.Tenancy.Abstractions.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Corvus.ContentHandling.Json" Version="0.13.0-preview.7" />
+    <PackageReference Include="Corvus.ContentHandling.Json" Version="0.13.0" />
     <PackageReference Include="Corvus.Extensions" Version="0.8.0" />
     <PackageReference Include="Endjin.RecommendedPractices" Version="0.3.0">
       <PrivateAssets>all</PrivateAssets>

--- a/Solutions/Corvus.Tenancy.Abstractions/Corvus.Tenancy.Abstractions.csproj
+++ b/Solutions/Corvus.Tenancy.Abstractions/Corvus.Tenancy.Abstractions.csproj
@@ -15,10 +15,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Corvus.ContentHandling.Json" Version="0.13.0-PullRequest0097.9" />
+    <PackageReference Include="Corvus.ContentHandling.Json" Version="0.13.0-preview.7" />
     <PackageReference Include="Corvus.Extensions" Version="0.8.0" />
-    <!-- TODO: we should remove this ref once we're done because it should come from Corvus.ContentHandling.Json -->
-    <PackageReference Include="Corvus.Extensions.Newtonsoft.Json" Version="0.10.0-PullRequest0087.20" />
     <PackageReference Include="Endjin.RecommendedPractices" Version="0.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Solutions/Corvus.Tenancy.Abstractions/Corvus.Tenancy.Abstractions.csproj
+++ b/Solutions/Corvus.Tenancy.Abstractions/Corvus.Tenancy.Abstractions.csproj
@@ -1,5 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="$(EndjinProjectPropsPath)" />
+  
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Nullable>enable</Nullable>
@@ -13,13 +15,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Corvus.ContentHandling.Json" Version="0.12.0" />
+    <PackageReference Include="Corvus.ContentHandling.Json" Version="0.13.0-PullRequest0097.9" />
     <PackageReference Include="Corvus.Extensions" Version="0.8.0" />
-    <PackageReference Include="Endjin.RecommendedPractices" Version="0.1.0">
+    <!-- TODO: we should remove this ref once we're done because it should come from Corvus.ContentHandling.Json -->
+    <PackageReference Include="Corvus.Extensions.Newtonsoft.Json" Version="0.10.0-PullRequest0087.18" />
+    <PackageReference Include="Endjin.RecommendedPractices" Version="0.2.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Primitives" Version="2.2.0" />
+    <PackageReference Include="Nullable" Version="1.2.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/Solutions/Corvus.Tenancy.Abstractions/Corvus.Tenancy.Abstractions.csproj
+++ b/Solutions/Corvus.Tenancy.Abstractions/Corvus.Tenancy.Abstractions.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Corvus.ContentHandling.Json" Version="0.13.0-PullRequest0097.9" />
     <PackageReference Include="Corvus.Extensions" Version="0.8.0" />
     <!-- TODO: we should remove this ref once we're done because it should come from Corvus.ContentHandling.Json -->
-    <PackageReference Include="Corvus.Extensions.Newtonsoft.Json" Version="0.10.0-PullRequest0087.18" />
+    <PackageReference Include="Corvus.Extensions.Newtonsoft.Json" Version="0.10.0-PullRequest0087.20" />
     <PackageReference Include="Endjin.RecommendedPractices" Version="0.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Solutions/Corvus.Tenancy.Abstractions/Corvus/Tenancy/ITenant.cs
+++ b/Solutions/Corvus.Tenancy.Abstractions/Corvus/Tenancy/ITenant.cs
@@ -4,7 +4,7 @@
 
 namespace Corvus.Tenancy
 {
-    using Corvus.Extensions.Json;
+    using Corvus.Json;
 
     /// <summary>
     /// Describes a tenant in a multitenanted system.

--- a/Solutions/Corvus.Tenancy.Abstractions/Corvus/Tenancy/ITenant.cs
+++ b/Solutions/Corvus.Tenancy.Abstractions/Corvus/Tenancy/ITenant.cs
@@ -41,7 +41,7 @@ namespace Corvus.Tenancy
         /// <summary>
         /// Gets the collection of properties for this tenant.
         /// </summary>
-        PropertyBag Properties { get; }
+        IPropertyBag Properties { get; }
 
         /// <summary>
         /// Gets or sets the ETag of the tenant.

--- a/Solutions/Corvus.Tenancy.Abstractions/Corvus/Tenancy/ITenantProvider.cs
+++ b/Solutions/Corvus.Tenancy.Abstractions/Corvus/Tenancy/ITenantProvider.cs
@@ -4,19 +4,18 @@
 
 namespace Corvus.Tenancy
 {
-    using System;
     using System.Threading.Tasks;
     using Corvus.Tenancy.Exceptions;
 
     /// <summary>
-    /// Provides tenant information.
+    /// Provides access to tenant information by id.
     /// </summary>
     public interface ITenantProvider
     {
         /// <summary>
         /// Gets the root tenant.
         /// </summary>
-        ITenant Root { get; }
+        RootTenant Root { get; }
 
         /// <summary>
         /// Gets the tenant for a given tenant ID.
@@ -33,46 +32,5 @@ namespace Corvus.Tenancy
         /// Thrown if no tenant with the specified id can be found.
         /// </exception>
         Task<ITenant> GetTenantAsync(string tenantId, string? eTag = null);
-
-        /// <summary>
-        /// Gets the child tenants for a given tenant.
-        /// </summary>
-        /// <param name="tenantId">The id of the tenant for which to get the direct children.</param>
-        /// <param name="limit">The maximum number of children to get in a single request.</param>
-        /// <param name="continuationToken">A continuation token to continue reading the next batch.</param>
-        /// <returns>The list of tenants who are children of that tenant.</returns>
-        Task<TenantCollectionResult> GetChildrenAsync(string tenantId, int limit = 20, string? continuationToken = null);
-
-        /// <summary>
-        /// Creates a child tenant for a parent.
-        /// </summary>
-        /// <param name="parentTenantId">The id of the tenant in which to create the child tenant.</param>
-        /// <param name="name">The name of the child tenant.</param>
-        /// <returns>The tenant that was created.</returns>
-        Task<ITenant> CreateChildTenantAsync(string parentTenantId, string name);
-
-        /// <summary>
-        /// Creates a child tenant for a parent using a well known identifier as the basis of the new tenant's Id.
-        /// </summary>
-        /// <param name="parentTenantId">The id of the tenant in which to create the child tenant.</param>
-        /// <param name="wellKnownChildTenantGuid">The well known identifier to use when constructing the new tenant's Id.</param>
-        /// <param name="name">The name of the child tenant.</param>
-        /// <returns>The tenant that was created.</returns>
-        Task<ITenant> CreateWellKnownChildTenantAsync(string parentTenantId, Guid wellKnownChildTenantGuid, string name);
-
-        /// <summary>
-        /// Updates a tenant.
-        /// </summary>
-        /// <param name="tenant">The tenant to update.</param>
-        /// <returns>The updated tenant.</returns>
-        /// <remarks>Note that this will update the ETag of the tenant.</remarks>
-        Task<ITenant> UpdateTenantAsync(ITenant tenant);
-
-        /// <summary>
-        /// Deletes the given tenant.
-        /// </summary>
-        /// <param name="tenantId">The tenant ID.</param>
-        /// <returns>A <see cref="Task"/> which completes once the tenant is deleted.</returns>
-        Task DeleteTenantAsync(string tenantId);
     }
 }

--- a/Solutions/Corvus.Tenancy.Abstractions/Corvus/Tenancy/ITenantStore.cs
+++ b/Solutions/Corvus.Tenancy.Abstractions/Corvus/Tenancy/ITenantStore.cs
@@ -43,22 +43,28 @@ namespace Corvus.Tenancy
         /// Updates a tenant.
         /// </summary>
         /// <param name="tenantId">The ID of the tenant to update.</param>
+        /// <param name="name">
+        /// The name to set for this tenant, or null if the caller wants only to add, modify, or
+        /// remove properties.
+        /// </param>
         /// <param name="propertiesToSetOrAdd">
         /// Key and value pairs to update in or add to the tenant's <see cref="ITenant.Properties"/>,
-        /// or null if the caller wants only to remove properties.
+        /// or null if the caller wants only to set the name or remove properties.
         /// </param>
         /// <param name="propertiesToRemove">
         /// The keys of the properties to remove from the tenant's <see cref="ITenant.Properties"/>,
-        /// or null if the caller only wants to add or modify properties.
+        /// or null if the caller only wants to set the name or add or modify properties.
         /// </param>
         /// <returns>The updated tenant.</returns>
         /// <exception cref="ArgumentNullException">
-        /// At least one of <c>propertiesToSetOrAdd</c> or <c>propertiesToRemove</c> must be non-null.
-        /// If both are null, the call would have no effect, so we throw this exception.
+        /// At least one of <c>name</c>, <c>propertiesToSetOrAdd</c>, or <c>propertiesToRemove</c>
+        /// must be non-null. If all are null, the call would have no effect, so we throw this
+        /// exception.
         /// </exception>
         /// <remarks>Note that this will update the ETag of the tenant.</remarks>
         Task<ITenant> UpdateTenantAsync(
             string tenantId,
+            string? name = null,
             IEnumerable<KeyValuePair<string, object>>? propertiesToSetOrAdd = null,
             IEnumerable<string>? propertiesToRemove = null);
 

--- a/Solutions/Corvus.Tenancy.Abstractions/Corvus/Tenancy/ITenantStore.cs
+++ b/Solutions/Corvus.Tenancy.Abstractions/Corvus/Tenancy/ITenantStore.cs
@@ -1,0 +1,72 @@
+﻿// <copyright file="ITenantStore.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+namespace Corvus.Tenancy
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// Provides the ability to explore the hierarchy of a tenant store, and update tenant details.
+    /// </summary>
+    public interface ITenantStore : ITenantProvider
+    {
+        /// <summary>
+        /// Gets the child tenants for a given tenant.
+        /// </summary>
+        /// <param name="tenantId">The id of the tenant for which to get the direct children.</param>
+        /// <param name="limit">The maximum number of children to get in a single request.</param>
+        /// <param name="continuationToken">A continuation token to continue reading the next batch.</param>
+        /// <returns>The list of tenants who are children of that tenant.</returns>
+        Task<TenantCollectionResult> GetChildrenAsync(string tenantId, int limit = 20, string? continuationToken = null);
+
+        /// <summary>
+        /// Creates a child tenant for a parent.
+        /// </summary>
+        /// <param name="parentTenantId">The id of the tenant in which to create the child tenant.</param>
+        /// <param name="name">The name of the child tenant.</param>
+        /// <returns>The tenant that was created.</returns>
+        Task<ITenant> CreateChildTenantAsync(string parentTenantId, string name);
+
+        /// <summary>
+        /// Creates a child tenant for a parent using a well known identifier as the basis of the new tenant's Id.
+        /// </summary>
+        /// <param name="parentTenantId">The id of the tenant in which to create the child tenant.</param>
+        /// <param name="wellKnownChildTenantGuid">The well known identifier to use when constructing the new tenant's Id.</param>
+        /// <param name="name">The name of the child tenant.</param>
+        /// <returns>The tenant that was created.</returns>
+        Task<ITenant> CreateWellKnownChildTenantAsync(string parentTenantId, Guid wellKnownChildTenantGuid, string name);
+
+        /// <summary>
+        /// Updates a tenant.
+        /// </summary>
+        /// <param name="tenantId">The ID of the tenant to update.</param>
+        /// <param name="propertiesToSetOrAdd">
+        /// Key and value pairs to update in or add to the tenant's <see cref="ITenant.Properties"/>,
+        /// or null if the caller wants only to remove properties.
+        /// </param>
+        /// <param name="propertiesToRemove">
+        /// The keys of the properties to remove from the tenant's <see cref="ITenant.Properties"/>,
+        /// or null if the caller only wants to add or modify properties.
+        /// </param>
+        /// <returns>The updated tenant.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// At least one of <c>propertiesToSetOrAdd</c> or <c>propertiesToRemove</c> must be non-null.
+        /// If both are null, the call would have no effect, so we throw this exception.
+        /// </exception>
+        /// <remarks>Note that this will update the ETag of the tenant.</remarks>
+        Task<ITenant> UpdateTenantAsync(
+            string tenantId,
+            IEnumerable<KeyValuePair<string, object>>? propertiesToSetOrAdd = null,
+            IEnumerable<string>? propertiesToRemove = null);
+
+        /// <summary>
+        /// Deletes the given tenant.
+        /// </summary>
+        /// <param name="tenantId">The tenant ID.</param>
+        /// <returns>A <see cref="Task"/> which completes once the tenant is deleted.</returns>
+        Task DeleteTenantAsync(string tenantId);
+    }
+}

--- a/Solutions/Corvus.Tenancy.Abstractions/Corvus/Tenancy/RootTenant.cs
+++ b/Solutions/Corvus.Tenancy.Abstractions/Corvus/Tenancy/RootTenant.cs
@@ -6,8 +6,7 @@ namespace Corvus.Tenancy
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
-    using Corvus.Extensions.Json;
+    using Corvus.Json;
 
     /// <summary>
     /// Describes a root tenant in a multitenanted system.
@@ -36,7 +35,7 @@ namespace Corvus.Tenancy
         /// </summary>
         /// <param name="propertyBagFactory">Enables property bag creation and update.</param>
         public RootTenant(IPropertyBagFactory propertyBagFactory)
-            : base(RootTenantId, RootTenantName, propertyBagFactory.Create(Enumerable.Empty<KeyValuePair<string, object?>>()))
+            : base(RootTenantId, RootTenantName, propertyBagFactory.Create(PropertyBagValues.Empty))
         {
             this.propertyBagFactory = propertyBagFactory;
         }
@@ -63,7 +62,7 @@ namespace Corvus.Tenancy
         {
             this.Properties = this.propertyBagFactory.CreateModified(
                 this.Properties,
-                propertiesToSetOrAdd?.NonNullToNullable(),
+                propertiesToSetOrAdd,
                 propertiesToRemove);
         }
     }

--- a/Solutions/Corvus.Tenancy.Abstractions/Corvus/Tenancy/RootTenant.cs
+++ b/Solutions/Corvus.Tenancy.Abstractions/Corvus/Tenancy/RootTenant.cs
@@ -5,6 +5,8 @@
 namespace Corvus.Tenancy
 {
     using System;
+    using System.Collections.Generic;
+    using System.Linq;
     using Corvus.Extensions.Json;
 
     /// <summary>
@@ -27,16 +29,42 @@ namespace Corvus.Tenancy
         /// This is encoded to <c>f26450ab1668784bb327951c8b08f347</c>.
         /// </remarks>
         public static readonly string RootTenantId = Guid.Parse("AB5064F2-6816-4B78-B327-951C8B08F347").EncodeGuid();
+        private readonly IPropertyBagFactory propertyBagFactory;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RootTenant"/> class.
         /// </summary>
-        /// <param name="serializerSettingsProvider">The Json Serializer Settings provider.</param>
-        public RootTenant(IJsonSerializerSettingsProvider serializerSettingsProvider)
-            : base(serializerSettingsProvider)
+        /// <param name="propertyBagFactory">Enables property bag creation and update.</param>
+        public RootTenant(IPropertyBagFactory propertyBagFactory)
+            : base(RootTenantId, RootTenantName, propertyBagFactory.Create(Enumerable.Empty<KeyValuePair<string, object?>>()))
         {
-            this.Id = RootTenantId;
-            this.Name = RootTenantName;
+            this.propertyBagFactory = propertyBagFactory;
+        }
+
+        /// <summary>
+        /// Updates the root tenant's properties. This is a special case because it supports synchronous updates.
+        /// </summary>
+        /// <param name="propertiesToSetOrAdd">
+        /// Key and value pairs to update in or add to the tenant's <see cref="ITenant.Properties"/>,
+        /// or null if the caller wants only to remove properties.
+        /// </param>
+        /// <param name="propertiesToRemove">
+        /// The keys of the properties to remove from the tenant's <see cref="ITenant.Properties"/>,
+        /// or null if the caller only wants to add or modify properties.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// At least one of <c>propertiesToSetOrAdd</c> or <c>propertiesToRemove</c> must be non-null.
+        /// If both are null, the call would have no effect, so we throw this exception.
+        /// </exception>
+        /// <remarks>Note that this will update the ETag of the tenant.</remarks>
+        public void UpdateProperties(
+            IEnumerable<KeyValuePair<string, object>>? propertiesToSetOrAdd = null,
+            IEnumerable<string>? propertiesToRemove = null)
+        {
+            this.Properties = this.propertyBagFactory.CreateModified(
+                this.Properties,
+                propertiesToSetOrAdd?.NonNullToNullable(),
+                propertiesToRemove);
         }
     }
 }

--- a/Solutions/Corvus.Tenancy.Abstractions/Corvus/Tenancy/Tenant.cs
+++ b/Solutions/Corvus.Tenancy.Abstractions/Corvus/Tenancy/Tenant.cs
@@ -4,7 +4,7 @@
 
 namespace Corvus.Tenancy
 {
-    using Corvus.Extensions.Json;
+    using Corvus.Json;
 
     /// <summary>
     /// Describes a tenant in a multitenanted system.

--- a/Solutions/Corvus.Tenancy.Abstractions/Corvus/Tenancy/Tenant.cs
+++ b/Solutions/Corvus.Tenancy.Abstractions/Corvus/Tenancy/Tenant.cs
@@ -4,7 +4,6 @@
 
 namespace Corvus.Tenancy
 {
-    using System;
     using Corvus.Extensions.Json;
 
     /// <summary>
@@ -17,52 +16,47 @@ namespace Corvus.Tenancy
         /// </summary>
         public const string RegisteredContentType = "application/vnd.corvus.tenancy.tenant";
 
-        private string? id;
-        private string? name;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="Tenant"/> class.
         /// </summary>
-        /// <param name="settingsProvider">The json serializer settings provider.</param>
-        public Tenant(IJsonSerializerSettingsProvider settingsProvider)
+        /// <param name="id">The <see cref="Id"/>.</param>
+        /// <param name="name">The <see cref="Name"/>.</param>
+        /// <param name="properties">The <see cref="Properties"/>.</param>
+        public Tenant(string id, string name, IPropertyBag properties)
         {
-            if (settingsProvider is null)
+            if (id is null)
             {
-                throw new System.ArgumentNullException(nameof(settingsProvider));
+                throw new System.ArgumentNullException(nameof(id));
             }
 
-            this.Properties = new PropertyBag(settingsProvider.Instance);
+            if (name is null)
+            {
+                throw new System.ArgumentNullException(nameof(id));
+            }
 
-            this.Id = string.Empty;
+            if (properties is null)
+            {
+                throw new System.ArgumentNullException(nameof(id));
+            }
+
+            this.Id = id;
+            this.Name = name;
+            this.Properties = properties;
         }
 
         /// <inheritdoc/>
-        public string Id
-        {
-            get => this.id ?? throw new InvalidOperationException("This tenant has not been supplied with an " + nameof(this.Id));
-            set => this.id = value ?? throw new ArgumentNullException();
-        }
+        public string Id { get; }
 
         /// <inheritdoc/>
-        public string Name
-        {
-            get => this.name ?? throw new InvalidOperationException("This tenant has not been supplied with a " + nameof(this.Name));
-            set => this.name = value ?? throw new ArgumentNullException();
-        }
+        public string Name { get; }
 
         /// <inheritdoc/>
-        public PropertyBag Properties
-        {
-            get; set;
-        }
+        public IPropertyBag Properties { get; protected set; }
 
         /// <inheritdoc/>
         public string? ETag { get; set; }
 
         /// <inheritdoc/>
-        public string ContentType
-        {
-            get { return RegisteredContentType; }
-        }
+        public string ContentType => RegisteredContentType;
     }
 }

--- a/Solutions/Corvus.Tenancy.Abstractions/Corvus/Tenancy/TenantExtensions.cs
+++ b/Solutions/Corvus.Tenancy.Abstractions/Corvus/Tenancy/TenantExtensions.cs
@@ -7,7 +7,7 @@ namespace Corvus.Tenancy
     using System;
     using System.Collections.Generic;
     using System.IO;
-    using System.Linq;
+    using Corvus.Extensions.Json;
 
     /// <summary>
     /// Extensions for the <see cref="ITenant"/>.
@@ -171,6 +171,24 @@ namespace Corvus.Tenancy
             return new string(result);
         }
 #pragma warning restore RCS1224 // Make method an extension method.
+
+        /// <summary>
+        /// Updates the root tenant's properties, using a callback that produces a collection of
+        /// key pair values where the values are all typed as non-null objects to describe the
+        /// properties to add or change.
+        /// </summary>
+        /// <param name="rootTenant">The root tenant to configure.</param>
+        /// <param name="builder">A function that builds the collection describing the properties to add.</param>
+        /// <param name="propertiesToRemove">Optional list of properties to remove.</param>
+        public static void UpdateProperties(
+            this RootTenant rootTenant,
+            Func<IEnumerable<KeyValuePair<string, object>>, IEnumerable<KeyValuePair<string, object>>> builder,
+            IEnumerable<string>? propertiesToRemove = null)
+        {
+            rootTenant.UpdateProperties(
+                builder(PropertyBagValues.EmptyNonNull),
+                propertiesToRemove);
+        }
 
         private static uint[] CreateLookup32()
         {

--- a/Solutions/Corvus.Tenancy.Abstractions/Corvus/Tenancy/TenantExtensions.cs
+++ b/Solutions/Corvus.Tenancy.Abstractions/Corvus/Tenancy/TenantExtensions.cs
@@ -7,7 +7,7 @@ namespace Corvus.Tenancy
     using System;
     using System.Collections.Generic;
     using System.IO;
-    using Corvus.Extensions.Json;
+    using Corvus.Json;
 
     /// <summary>
     /// Extensions for the <see cref="ITenant"/>.
@@ -186,7 +186,7 @@ namespace Corvus.Tenancy
             IEnumerable<string>? propertiesToRemove = null)
         {
             rootTenant.UpdateProperties(
-                builder(PropertyBagValues.EmptyNonNull),
+                builder(PropertyBagValues.Empty),
                 propertiesToRemove);
         }
 

--- a/Solutions/Corvus.Tenancy.Abstractions/Microsoft/Extensions/DependencyInjection/TenantServiceCollectionExtensions.cs
+++ b/Solutions/Corvus.Tenancy.Abstractions/Microsoft/Extensions/DependencyInjection/TenantServiceCollectionExtensions.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 return services;
             }
 
-            services.AddContentSerialization(contentFactory => contentFactory.RegisterTransientContent<Tenant>());
+            services.AddContentSerialization(contentFactory => contentFactory.RegisterContent<Tenant>());
 
             services.AddSingleton<RootTenant>();
             return services;

--- a/Solutions/Corvus.Tenancy.Specs/Bindings/FakeTenantProvider.cs
+++ b/Solutions/Corvus.Tenancy.Specs/Bindings/FakeTenantProvider.cs
@@ -13,7 +13,7 @@
             this.Root = rootTenant;
         }
 
-        public ITenant Root { get; }
+        public RootTenant Root { get; }
 
         public Task<ITenant> CreateChildTenantAsync(string parentTenantId, string name)
         {
@@ -53,7 +53,7 @@
                 throw new TenantNotFoundException();
             }
 
-            return Task.FromResult(this.Root);
+            return Task.FromResult<ITenant>(this.Root);
         }
 
         public Task<ITenant> UpdateTenantAsync(ITenant tenant)

--- a/Solutions/Corvus.Tenancy.Specs/Bindings/FakeTenantProvider.cs
+++ b/Solutions/Corvus.Tenancy.Specs/Bindings/FakeTenantProvider.cs
@@ -5,6 +5,7 @@
     using Corvus.Tenancy;
     using Corvus.Tenancy.Exceptions;
 
+#pragma warning disable IDE0060 // Unused arguments
     internal class FakeTenantProvider : ITenantProvider
     {
         public FakeTenantProvider(RootTenant rootTenant)

--- a/Solutions/Corvus.Tenancy.Specs/Bindings/TenancyCloudBlobContainerBindings.cs
+++ b/Solutions/Corvus.Tenancy.Specs/Bindings/TenancyCloudBlobContainerBindings.cs
@@ -44,7 +44,7 @@ namespace Corvus.Tenancy.Specs.Bindings
             var blobStorageContainerDefinition = new BlobStorageContainerDefinition($"{containerBase}tenancyspecs");
             var blobStorageConfiguration = new BlobStorageConfiguration();
             config.Bind("TESTBLOBSTORAGECONFIGURATIONOPTIONS", blobStorageConfiguration);
-            tenantProvider.Root.SetBlobStorageConfiguration(blobStorageContainerDefinition, blobStorageConfiguration);
+            tenantProvider.Root.UpdateProperties(values => values.AddBlobStorageConfiguration(blobStorageContainerDefinition, blobStorageConfiguration));
 
             CloudBlobContainer tenancySpecsContainer = await factory.GetBlobContainerForTenantAsync(
                 tenantProvider.Root,

--- a/Solutions/Corvus.Tenancy.Specs/Bindings/TenancyContainerBindings.cs
+++ b/Solutions/Corvus.Tenancy.Specs/Bindings/TenancyContainerBindings.cs
@@ -58,11 +58,13 @@ namespace Corvus.Tenancy.Specs.Bindings
                             return blobStorageConfiguration;
                         });
 
-                        // Now replace the service for ITenantProvider with a decorated TenantProviderBlobStore.
+                        // Now replace the service for ITenantStore and ITenantProvider with a decorated TenantProviderBlobStore.
                         serviceCollection.AddSingleton(sp => new TenantTrackingTenantProviderDecorator(
                                 sp.GetRequiredService<TenantProviderBlobStore>()));
                         serviceCollection.Remove(serviceCollection.First(x => x.ServiceType == typeof(ITenantProvider)));
                         serviceCollection.AddSingleton<ITenantProvider>(
+                            sp => sp.GetRequiredService<TenantTrackingTenantProviderDecorator>());
+                        serviceCollection.AddSingleton<ITenantStore>(
                             sp => sp.GetRequiredService<TenantTrackingTenantProviderDecorator>());
                     }
                     else

--- a/Solutions/Corvus.Tenancy.Specs/Bindings/TenancyCosmosContainerBindings.cs
+++ b/Solutions/Corvus.Tenancy.Specs/Bindings/TenancyCosmosContainerBindings.cs
@@ -51,7 +51,7 @@ namespace Corvus.Tenancy.Specs.Bindings
             config.Bind("TESTCOSMOSCONFIGURATIONOPTIONS", cosmosConfiguration);
             cosmosConfiguration.DatabaseName = "endjinspecssharedthroughput";
             cosmosConfiguration.DisableTenantIdPrefix = true;
-            tenantProvider.Root.SetCosmosConfiguration(cosmosContainerDefinition, cosmosConfiguration);
+            tenantProvider.Root.UpdateProperties(values => values.AddCosmosConfiguration(cosmosContainerDefinition, cosmosConfiguration));
 
             Container tenancySpecsContainer = await factory.GetContainerForTenantAsync(
                 tenantProvider.Root,

--- a/Solutions/Corvus.Tenancy.Specs/Bindings/TenancyGremlinContainerBindings.cs
+++ b/Solutions/Corvus.Tenancy.Specs/Bindings/TenancyGremlinContainerBindings.cs
@@ -49,7 +49,7 @@ namespace Corvus.Tenancy.Specs.Bindings
             config.Bind("TESTGREMLINCONFIGURATIONOPTIONS", gremlinConfiguration);
             gremlinConfiguration.DatabaseName = "endjinspecssharedthroughput";
             gremlinConfiguration.DisableTenantIdPrefix = true;
-            tenantProvider.Root.SetGremlinConfiguration(gremlinContainerDefinition, gremlinConfiguration);
+            tenantProvider.Root.UpdateProperties(values => values.AddGremlinConfiguration(gremlinContainerDefinition, gremlinConfiguration));
 
             GremlinClient tenancySpecsClient = await factory.GetClientForTenantAsync(
                 tenantProvider.Root,

--- a/Solutions/Corvus.Tenancy.Specs/Bindings/TenantTrackingTenantProviderDecorator.cs
+++ b/Solutions/Corvus.Tenancy.Specs/Bindings/TenantTrackingTenantProviderDecorator.cs
@@ -7,12 +7,13 @@ namespace Corvus.Tenancy.Specs.Bindings
     using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;
+    using Corvus.Tenancy;
 
-    public class TenantTrackingTenantProviderDecorator : ITenantProvider
+    public class TenantTrackingTenantProviderDecorator : ITenantStore
     {
-        private readonly ITenantProvider decoratedProvider;
+        private readonly ITenantStore decoratedProvider;
 
-        public TenantTrackingTenantProviderDecorator(ITenantProvider decoratedProvider)
+        public TenantTrackingTenantProviderDecorator(ITenantStore decoratedProvider)
         {
             this.decoratedProvider = decoratedProvider ?? throw new ArgumentNullException(nameof(decoratedProvider));
         }
@@ -47,7 +48,7 @@ namespace Corvus.Tenancy.Specs.Bindings
         public Task<ITenant> GetTenantAsync(string tenantId, string? eTag = null)
             => this.decoratedProvider.GetTenantAsync(tenantId, eTag);
 
-        public Task<ITenant> UpdateTenantAsync(ITenant tenant)
-            => this.decoratedProvider.UpdateTenantAsync(tenant);
+        public Task<ITenant> UpdateTenantAsync(string tenantId, IEnumerable<KeyValuePair<string, object>>? propertiesToSetOrAdd = null, IEnumerable<string>? propertiesToRemove = null)
+            => this.decoratedProvider.UpdateTenantAsync(tenantId, propertiesToSetOrAdd, propertiesToRemove);
     }
 }

--- a/Solutions/Corvus.Tenancy.Specs/Bindings/TenantTrackingTenantProviderDecorator.cs
+++ b/Solutions/Corvus.Tenancy.Specs/Bindings/TenantTrackingTenantProviderDecorator.cs
@@ -48,7 +48,7 @@ namespace Corvus.Tenancy.Specs.Bindings
         public Task<ITenant> GetTenantAsync(string tenantId, string? eTag = null)
             => this.decoratedProvider.GetTenantAsync(tenantId, eTag);
 
-        public Task<ITenant> UpdateTenantAsync(string tenantId, IEnumerable<KeyValuePair<string, object>>? propertiesToSetOrAdd = null, IEnumerable<string>? propertiesToRemove = null)
-            => this.decoratedProvider.UpdateTenantAsync(tenantId, propertiesToSetOrAdd, propertiesToRemove);
+        public Task<ITenant> UpdateTenantAsync(string tenantId, string? name, IEnumerable<KeyValuePair<string, object>>? propertiesToSetOrAdd = null, IEnumerable<string>? propertiesToRemove = null)
+            => this.decoratedProvider.UpdateTenantAsync(tenantId, name, propertiesToSetOrAdd, propertiesToRemove);
     }
 }

--- a/Solutions/Corvus.Tenancy.Specs/Bindings/TenantTrackingTenantProviderDecorator.cs
+++ b/Solutions/Corvus.Tenancy.Specs/Bindings/TenantTrackingTenantProviderDecorator.cs
@@ -20,7 +20,7 @@ namespace Corvus.Tenancy.Specs.Bindings
 
         public List<ITenant> CreatedTenants { get; } = new List<ITenant>();
 
-        public ITenant Root => this.decoratedProvider.Root;
+        public RootTenant Root => this.decoratedProvider.Root;
 
         public async Task<ITenant> CreateChildTenantAsync(string parentTenantId, string name)
         {

--- a/Solutions/Corvus.Tenancy.Specs/Corvus.Tenancy.Specs.csproj
+++ b/Solutions/Corvus.Tenancy.Specs/Corvus.Tenancy.Specs.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="$(EndjinProjectPropsPath)" />
+  <Import Project="$(EndjinProjectPropsPath)" Condition="$(EndjinProjectPropsPath) != ''" />
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Corvus.SpecFlow.Extensions" Version="0.6.0" />
-    <PackageReference Include="Endjin.RecommendedPractices" Version="0.2.1">
+    <PackageReference Include="Endjin.RecommendedPractices" Version="0.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Solutions/Corvus.Tenancy.Specs/Corvus.Tenancy.Specs.csproj
+++ b/Solutions/Corvus.Tenancy.Specs/Corvus.Tenancy.Specs.csproj
@@ -1,5 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="$(EndjinProjectPropsPath)" />
+
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
@@ -16,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Corvus.SpecFlow.Extensions" Version="0.6.0" />
-    <PackageReference Include="Endjin.RecommendedPractices" Version="0.1.0">
+    <PackageReference Include="Endjin.RecommendedPractices" Version="0.2.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Solutions/Corvus.Tenancy.Specs/Features/TenantStorage.feature
+++ b/Solutions/Corvus.Tenancy.Specs/Features/TenantStorage.feature
@@ -56,7 +56,7 @@ Scenario: Creating children that have the same well known Ids under different pa
 	And The tenant called "ChildTenant3" has tenant Id "6e2d182a13ff734a87af0b58d82436036e2d182a13ff734a87af0b58d8243603"
 	And The tenant called "ChildTenant4" has tenant Id "a1756d0807da904cbea7857a6c1262806e2d182a13ff734a87af0b58d8243603"
 
-Scenario: Update a child tenant
+Scenario: Add properties to a child tenant that has no properties
 	Given I create a child tenant called "ChildTenant1" for the root tenant
 	When I update the properties of the tenant called "ChildTenant1"
 	| Key       | Value            | Type           |
@@ -71,6 +71,116 @@ Scenario: Update a child tenant
 	| FirstKey  | 1                | integer        |
 	| SecondKey | This is a string | string         |
 	| ThirdKey  | 1999-01-17       | datetimeoffset |
+
+Scenario: Modify properties of a child tenant
+	Given I create a child tenant called "ChildTenant1" for the root tenant
+	And I update the properties of the tenant called "ChildTenant1"
+	| Key       | Value            | Type           |
+	| FirstKey  | 1                | integer        |
+	| SecondKey | This is a string | string         |
+	| ThirdKey  | 1999-01-17       | datetimeoffset |
+	When I update the properties of the tenant called "ChildTenant1" and call the returned tenant "UpdateResult"
+	| Key       | Value                      | Type    |
+	| FirstKey  | 2                          | integer |
+	| SecondKey | This is a different string | string  |
+	And I get the tenant id of the tenant called "ChildTenant1" and call it "ChildTenantId"
+	And I get the tenant with the id called "ChildTenantId" and call it "Result"
+	Then the tenant called "ChildTenant1" should have the same ID as the tenant called "Result"
+	And the tenant called "UpdateResult" should have the properties
+	| Key       | Value                      | Type           |
+	| FirstKey  | 2                          | integer        |
+	| SecondKey | This is a different string | string         |
+	| ThirdKey  | 1999-01-17                 | datetimeoffset |
+	And the tenant called "Result" should have the properties
+	| Key       | Value                      | Type           |
+	| FirstKey  | 2                          | integer        |
+	| SecondKey | This is a different string | string         |
+	| ThirdKey  | 1999-01-17                 | datetimeoffset |
+
+Scenario: Add properties to a child tenant that already has properties
+	Given I create a child tenant called "ChildTenant1" for the root tenant
+	And I update the properties of the tenant called "ChildTenant1"
+	| Key       | Value            | Type           |
+	| FirstKey  | 1                | integer        |
+	| SecondKey | This is a string | string         |
+	| ThirdKey  | 1999-01-17       | datetimeoffset |
+	When I update the properties of the tenant called "ChildTenant1" and call the returned tenant "UpdateResult"
+	| Key       | Value                      | Type    |
+	| FourthKey | 2                          | integer |
+	| FifthKey  | This is a different string | string  |
+	And I get the tenant id of the tenant called "ChildTenant1" and call it "ChildTenantId"
+	And I get the tenant with the id called "ChildTenantId" and call it "Result"
+	Then the tenant called "ChildTenant1" should have the same ID as the tenant called "Result"
+	And the tenant called "UpdateResult" should have the properties
+	| Key       | Value                      | Type           |
+	| FirstKey  | 1                          | integer        |
+	| SecondKey | This is a string           | string         |
+	| ThirdKey  | 1999-01-17                 | datetimeoffset |
+	| FourthKey | 2                          | integer        |
+	| FifthKey  | This is a different string | string         |
+	And the tenant called "Result" should have the properties
+	| Key       | Value                      | Type           |
+	| FirstKey  | 1                          | integer        |
+	| SecondKey | This is a string           | string         |
+	| ThirdKey  | 1999-01-17                 | datetimeoffset |
+	| FourthKey | 2                          | integer        |
+	| FifthKey  | This is a different string | string         |
+
+Scenario: Remove properties from a child tenant
+	Given I create a child tenant called "ChildTenant1" for the root tenant
+	And I update the properties of the tenant called "ChildTenant1"
+	| Key       | Value            | Type           |
+	| FirstKey  | 1                | integer        |
+	| SecondKey | This is a string | string         |
+	| ThirdKey  | 1999-01-17       | datetimeoffset |
+	When I remove the "SecondKey" property of the tenant called "ChildTenant1" and call the returned tenant "UpdateResult"
+	And I get the tenant id of the tenant called "ChildTenant1" and call it "ChildTenantId"
+	And I get the tenant with the id called "ChildTenantId" and call it "Result"
+	Then the tenant called "ChildTenant1" should have the same ID as the tenant called "Result"
+	And the tenant called "Result" should have the properties
+	| Key       | Value            | Type           |
+	| FirstKey  | 1                | integer        |
+	| ThirdKey  | 1999-01-17       | datetimeoffset |
+	And the tenant called "UpdateResult" should have the properties
+	| Key       | Value            | Type           |
+	| FirstKey  | 1                | integer        |
+	| ThirdKey  | 1999-01-17       | datetimeoffset |
+
+Scenario: Add, modify, and remove properties of a child tenant that already has properties
+	Given I create a child tenant called "ChildTenant1" for the root tenant
+	And I update the properties of the tenant called "ChildTenant1"
+	| Key       | Value            | Type           |
+	| FirstKey  | 1                | integer        |
+	| SecondKey | This is a string | string         |
+	| ThirdKey  | 1999-01-17       | datetimeoffset |
+	When I update the properties of the tenant called "ChildTenant1" and remove the "ThirdKey" property and call the returned tenant "UpdateResult"
+	| Key       | Value                      | Type    |
+	| SecondKey | This is a different string | string  |
+	| FourthKey | 2                          | integer |
+	| FifthKey  | This is a new string       | string  |
+	And I get the tenant id of the tenant called "ChildTenant1" and call it "ChildTenantId"
+	And I get the tenant with the id called "ChildTenantId" and call it "Result"
+	Then the tenant called "ChildTenant1" should have the same ID as the tenant called "Result"
+	And the tenant called "UpdateResult" should have the properties
+	| Key       | Value                      | Type           |
+	| FirstKey  | 1                          | integer        |
+	| SecondKey | This is a different string | string         |
+	| FourthKey | 2                          | integer        |
+	| FifthKey  | This is a new string       | string         |
+	And the tenant called "Result" should have the properties
+	| Key       | Value                      | Type           |
+	| FirstKey  | 1                          | integer        |
+	| SecondKey | This is a different string | string         |
+	| FourthKey | 2                          | integer        |
+	| FifthKey  | This is a new string       | string         |
+
+Scenario: Rename a child tenant
+	Given I create a child tenant called "ChildTenant1" for the root tenant
+	When I change the name of the tenant called "ChildTenant1" to "NewName" and call the returned tenant "UpdateResult"
+	And I get the tenant id of the tenant called "ChildTenant1" and call it "ChildTenantId"
+	And I get the tenant with the id called "ChildTenantId" and call it "Result"
+	Then the tenant called "ChildTenant1" should have the same ID as the tenant called "Result"
+	Then the tenant called "ChildTenant1" should have the same ID as the tenant called "Result"
 
 Scenario: Create a child of a child
 	Given I create a child tenant called "ChildTenant1" for the root tenant

--- a/Solutions/Corvus.Tenancy.Specs/Features/TenantStorage.feature.cs
+++ b/Solutions/Corvus.Tenancy.Specs/Features/TenantStorage.feature.cs
@@ -448,11 +448,11 @@ this.ScenarioInitialize(scenarioInfo);
         }
         
         [NUnit.Framework.TestAttribute()]
-        [NUnit.Framework.DescriptionAttribute("Update a child tenant")]
-        public virtual void UpdateAChildTenant()
+        [NUnit.Framework.DescriptionAttribute("Add properties to a child tenant that has no properties")]
+        public virtual void AddPropertiesToAChildTenantThatHasNoProperties()
         {
             string[] tagsOfScenario = ((string[])(null));
-            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Update a child tenant", null, ((string[])(null)));
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Add properties to a child tenant that has no properties", null, ((string[])(null)));
 #line 59
 this.ScenarioInitialize(scenarioInfo);
 #line hidden
@@ -530,11 +530,11 @@ this.ScenarioInitialize(scenarioInfo);
         }
         
         [NUnit.Framework.TestAttribute()]
-        [NUnit.Framework.DescriptionAttribute("Create a child of a child")]
-        public virtual void CreateAChildOfAChild()
+        [NUnit.Framework.DescriptionAttribute("Modify properties of a child tenant")]
+        public virtual void ModifyPropertiesOfAChildTenant()
         {
             string[] tagsOfScenario = ((string[])(null));
-            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Create a child of a child", null, ((string[])(null)));
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Modify properties of a child tenant", null, ((string[])(null)));
 #line 75
 this.ScenarioInitialize(scenarioInfo);
 #line hidden
@@ -558,18 +558,546 @@ this.ScenarioInitialize(scenarioInfo);
 #line 76
  testRunner.Given("I create a child tenant called \"ChildTenant1\" for the root tenant", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
 #line hidden
+                TechTalk.SpecFlow.Table table4 = new TechTalk.SpecFlow.Table(new string[] {
+                            "Key",
+                            "Value",
+                            "Type"});
+                table4.AddRow(new string[] {
+                            "FirstKey",
+                            "1",
+                            "integer"});
+                table4.AddRow(new string[] {
+                            "SecondKey",
+                            "This is a string",
+                            "string"});
+                table4.AddRow(new string[] {
+                            "ThirdKey",
+                            "1999-01-17",
+                            "datetimeoffset"});
 #line 77
+ testRunner.And("I update the properties of the tenant called \"ChildTenant1\"", ((string)(null)), table4, "And ");
+#line hidden
+                TechTalk.SpecFlow.Table table5 = new TechTalk.SpecFlow.Table(new string[] {
+                            "Key",
+                            "Value",
+                            "Type"});
+                table5.AddRow(new string[] {
+                            "FirstKey",
+                            "2",
+                            "integer"});
+                table5.AddRow(new string[] {
+                            "SecondKey",
+                            "This is a different string",
+                            "string"});
+#line 82
+ testRunner.When("I update the properties of the tenant called \"ChildTenant1\" and call the returned" +
+                        " tenant \"UpdateResult\"", ((string)(null)), table5, "When ");
+#line hidden
+#line 86
+ testRunner.And("I get the tenant id of the tenant called \"ChildTenant1\" and call it \"ChildTenantI" +
+                        "d\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 87
+ testRunner.And("I get the tenant with the id called \"ChildTenantId\" and call it \"Result\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 88
+ testRunner.Then("the tenant called \"ChildTenant1\" should have the same ID as the tenant called \"Re" +
+                        "sult\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line hidden
+                TechTalk.SpecFlow.Table table6 = new TechTalk.SpecFlow.Table(new string[] {
+                            "Key",
+                            "Value",
+                            "Type"});
+                table6.AddRow(new string[] {
+                            "FirstKey",
+                            "2",
+                            "integer"});
+                table6.AddRow(new string[] {
+                            "SecondKey",
+                            "This is a different string",
+                            "string"});
+                table6.AddRow(new string[] {
+                            "ThirdKey",
+                            "1999-01-17",
+                            "datetimeoffset"});
+#line 89
+ testRunner.And("the tenant called \"UpdateResult\" should have the properties", ((string)(null)), table6, "And ");
+#line hidden
+                TechTalk.SpecFlow.Table table7 = new TechTalk.SpecFlow.Table(new string[] {
+                            "Key",
+                            "Value",
+                            "Type"});
+                table7.AddRow(new string[] {
+                            "FirstKey",
+                            "2",
+                            "integer"});
+                table7.AddRow(new string[] {
+                            "SecondKey",
+                            "This is a different string",
+                            "string"});
+                table7.AddRow(new string[] {
+                            "ThirdKey",
+                            "1999-01-17",
+                            "datetimeoffset"});
+#line 94
+ testRunner.And("the tenant called \"Result\" should have the properties", ((string)(null)), table7, "And ");
+#line hidden
+            }
+            this.ScenarioCleanup();
+        }
+        
+        [NUnit.Framework.TestAttribute()]
+        [NUnit.Framework.DescriptionAttribute("Add properties to a child tenant that already has properties")]
+        public virtual void AddPropertiesToAChildTenantThatAlreadyHasProperties()
+        {
+            string[] tagsOfScenario = ((string[])(null));
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Add properties to a child tenant that already has properties", null, ((string[])(null)));
+#line 100
+this.ScenarioInitialize(scenarioInfo);
+#line hidden
+            bool isScenarioIgnored = default(bool);
+            bool isFeatureIgnored = default(bool);
+            if ((tagsOfScenario != null))
+            {
+                isScenarioIgnored = tagsOfScenario.Where(__entry => __entry != null).Where(__entry => String.Equals(__entry, "ignore", StringComparison.CurrentCultureIgnoreCase)).Any();
+            }
+            if ((this._featureTags != null))
+            {
+                isFeatureIgnored = this._featureTags.Where(__entry => __entry != null).Where(__entry => String.Equals(__entry, "ignore", StringComparison.CurrentCultureIgnoreCase)).Any();
+            }
+            if ((isScenarioIgnored || isFeatureIgnored))
+            {
+                testRunner.SkipScenario();
+            }
+            else
+            {
+                this.ScenarioStart();
+#line 101
+ testRunner.Given("I create a child tenant called \"ChildTenant1\" for the root tenant", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
+#line hidden
+                TechTalk.SpecFlow.Table table8 = new TechTalk.SpecFlow.Table(new string[] {
+                            "Key",
+                            "Value",
+                            "Type"});
+                table8.AddRow(new string[] {
+                            "FirstKey",
+                            "1",
+                            "integer"});
+                table8.AddRow(new string[] {
+                            "SecondKey",
+                            "This is a string",
+                            "string"});
+                table8.AddRow(new string[] {
+                            "ThirdKey",
+                            "1999-01-17",
+                            "datetimeoffset"});
+#line 102
+ testRunner.And("I update the properties of the tenant called \"ChildTenant1\"", ((string)(null)), table8, "And ");
+#line hidden
+                TechTalk.SpecFlow.Table table9 = new TechTalk.SpecFlow.Table(new string[] {
+                            "Key",
+                            "Value",
+                            "Type"});
+                table9.AddRow(new string[] {
+                            "FourthKey",
+                            "2",
+                            "integer"});
+                table9.AddRow(new string[] {
+                            "FifthKey",
+                            "This is a different string",
+                            "string"});
+#line 107
+ testRunner.When("I update the properties of the tenant called \"ChildTenant1\" and call the returned" +
+                        " tenant \"UpdateResult\"", ((string)(null)), table9, "When ");
+#line hidden
+#line 111
+ testRunner.And("I get the tenant id of the tenant called \"ChildTenant1\" and call it \"ChildTenantI" +
+                        "d\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 112
+ testRunner.And("I get the tenant with the id called \"ChildTenantId\" and call it \"Result\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 113
+ testRunner.Then("the tenant called \"ChildTenant1\" should have the same ID as the tenant called \"Re" +
+                        "sult\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line hidden
+                TechTalk.SpecFlow.Table table10 = new TechTalk.SpecFlow.Table(new string[] {
+                            "Key",
+                            "Value",
+                            "Type"});
+                table10.AddRow(new string[] {
+                            "FirstKey",
+                            "1",
+                            "integer"});
+                table10.AddRow(new string[] {
+                            "SecondKey",
+                            "This is a string",
+                            "string"});
+                table10.AddRow(new string[] {
+                            "ThirdKey",
+                            "1999-01-17",
+                            "datetimeoffset"});
+                table10.AddRow(new string[] {
+                            "FourthKey",
+                            "2",
+                            "integer"});
+                table10.AddRow(new string[] {
+                            "FifthKey",
+                            "This is a different string",
+                            "string"});
+#line 114
+ testRunner.And("the tenant called \"UpdateResult\" should have the properties", ((string)(null)), table10, "And ");
+#line hidden
+                TechTalk.SpecFlow.Table table11 = new TechTalk.SpecFlow.Table(new string[] {
+                            "Key",
+                            "Value",
+                            "Type"});
+                table11.AddRow(new string[] {
+                            "FirstKey",
+                            "1",
+                            "integer"});
+                table11.AddRow(new string[] {
+                            "SecondKey",
+                            "This is a string",
+                            "string"});
+                table11.AddRow(new string[] {
+                            "ThirdKey",
+                            "1999-01-17",
+                            "datetimeoffset"});
+                table11.AddRow(new string[] {
+                            "FourthKey",
+                            "2",
+                            "integer"});
+                table11.AddRow(new string[] {
+                            "FifthKey",
+                            "This is a different string",
+                            "string"});
+#line 121
+ testRunner.And("the tenant called \"Result\" should have the properties", ((string)(null)), table11, "And ");
+#line hidden
+            }
+            this.ScenarioCleanup();
+        }
+        
+        [NUnit.Framework.TestAttribute()]
+        [NUnit.Framework.DescriptionAttribute("Remove properties from a child tenant")]
+        public virtual void RemovePropertiesFromAChildTenant()
+        {
+            string[] tagsOfScenario = ((string[])(null));
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Remove properties from a child tenant", null, ((string[])(null)));
+#line 129
+this.ScenarioInitialize(scenarioInfo);
+#line hidden
+            bool isScenarioIgnored = default(bool);
+            bool isFeatureIgnored = default(bool);
+            if ((tagsOfScenario != null))
+            {
+                isScenarioIgnored = tagsOfScenario.Where(__entry => __entry != null).Where(__entry => String.Equals(__entry, "ignore", StringComparison.CurrentCultureIgnoreCase)).Any();
+            }
+            if ((this._featureTags != null))
+            {
+                isFeatureIgnored = this._featureTags.Where(__entry => __entry != null).Where(__entry => String.Equals(__entry, "ignore", StringComparison.CurrentCultureIgnoreCase)).Any();
+            }
+            if ((isScenarioIgnored || isFeatureIgnored))
+            {
+                testRunner.SkipScenario();
+            }
+            else
+            {
+                this.ScenarioStart();
+#line 130
+ testRunner.Given("I create a child tenant called \"ChildTenant1\" for the root tenant", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
+#line hidden
+                TechTalk.SpecFlow.Table table12 = new TechTalk.SpecFlow.Table(new string[] {
+                            "Key",
+                            "Value",
+                            "Type"});
+                table12.AddRow(new string[] {
+                            "FirstKey",
+                            "1",
+                            "integer"});
+                table12.AddRow(new string[] {
+                            "SecondKey",
+                            "This is a string",
+                            "string"});
+                table12.AddRow(new string[] {
+                            "ThirdKey",
+                            "1999-01-17",
+                            "datetimeoffset"});
+#line 131
+ testRunner.And("I update the properties of the tenant called \"ChildTenant1\"", ((string)(null)), table12, "And ");
+#line hidden
+#line 136
+ testRunner.When("I remove the \"SecondKey\" property of the tenant called \"ChildTenant1\" and call th" +
+                        "e returned tenant \"UpdateResult\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+#line 137
+ testRunner.And("I get the tenant id of the tenant called \"ChildTenant1\" and call it \"ChildTenantI" +
+                        "d\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 138
+ testRunner.And("I get the tenant with the id called \"ChildTenantId\" and call it \"Result\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 139
+ testRunner.Then("the tenant called \"ChildTenant1\" should have the same ID as the tenant called \"Re" +
+                        "sult\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line hidden
+                TechTalk.SpecFlow.Table table13 = new TechTalk.SpecFlow.Table(new string[] {
+                            "Key",
+                            "Value",
+                            "Type"});
+                table13.AddRow(new string[] {
+                            "FirstKey",
+                            "1",
+                            "integer"});
+                table13.AddRow(new string[] {
+                            "ThirdKey",
+                            "1999-01-17",
+                            "datetimeoffset"});
+#line 140
+ testRunner.And("the tenant called \"Result\" should have the properties", ((string)(null)), table13, "And ");
+#line hidden
+                TechTalk.SpecFlow.Table table14 = new TechTalk.SpecFlow.Table(new string[] {
+                            "Key",
+                            "Value",
+                            "Type"});
+                table14.AddRow(new string[] {
+                            "FirstKey",
+                            "1",
+                            "integer"});
+                table14.AddRow(new string[] {
+                            "ThirdKey",
+                            "1999-01-17",
+                            "datetimeoffset"});
+#line 144
+ testRunner.And("the tenant called \"UpdateResult\" should have the properties", ((string)(null)), table14, "And ");
+#line hidden
+            }
+            this.ScenarioCleanup();
+        }
+        
+        [NUnit.Framework.TestAttribute()]
+        [NUnit.Framework.DescriptionAttribute("Add, modify, and remove properties of a child tenant that already has properties")]
+        public virtual void AddModifyAndRemovePropertiesOfAChildTenantThatAlreadyHasProperties()
+        {
+            string[] tagsOfScenario = ((string[])(null));
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Add, modify, and remove properties of a child tenant that already has properties", null, ((string[])(null)));
+#line 149
+this.ScenarioInitialize(scenarioInfo);
+#line hidden
+            bool isScenarioIgnored = default(bool);
+            bool isFeatureIgnored = default(bool);
+            if ((tagsOfScenario != null))
+            {
+                isScenarioIgnored = tagsOfScenario.Where(__entry => __entry != null).Where(__entry => String.Equals(__entry, "ignore", StringComparison.CurrentCultureIgnoreCase)).Any();
+            }
+            if ((this._featureTags != null))
+            {
+                isFeatureIgnored = this._featureTags.Where(__entry => __entry != null).Where(__entry => String.Equals(__entry, "ignore", StringComparison.CurrentCultureIgnoreCase)).Any();
+            }
+            if ((isScenarioIgnored || isFeatureIgnored))
+            {
+                testRunner.SkipScenario();
+            }
+            else
+            {
+                this.ScenarioStart();
+#line 150
+ testRunner.Given("I create a child tenant called \"ChildTenant1\" for the root tenant", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
+#line hidden
+                TechTalk.SpecFlow.Table table15 = new TechTalk.SpecFlow.Table(new string[] {
+                            "Key",
+                            "Value",
+                            "Type"});
+                table15.AddRow(new string[] {
+                            "FirstKey",
+                            "1",
+                            "integer"});
+                table15.AddRow(new string[] {
+                            "SecondKey",
+                            "This is a string",
+                            "string"});
+                table15.AddRow(new string[] {
+                            "ThirdKey",
+                            "1999-01-17",
+                            "datetimeoffset"});
+#line 151
+ testRunner.And("I update the properties of the tenant called \"ChildTenant1\"", ((string)(null)), table15, "And ");
+#line hidden
+                TechTalk.SpecFlow.Table table16 = new TechTalk.SpecFlow.Table(new string[] {
+                            "Key",
+                            "Value",
+                            "Type"});
+                table16.AddRow(new string[] {
+                            "SecondKey",
+                            "This is a different string",
+                            "string"});
+                table16.AddRow(new string[] {
+                            "FourthKey",
+                            "2",
+                            "integer"});
+                table16.AddRow(new string[] {
+                            "FifthKey",
+                            "This is a new string",
+                            "string"});
+#line 156
+ testRunner.When("I update the properties of the tenant called \"ChildTenant1\" and remove the \"Third" +
+                        "Key\" property and call the returned tenant \"UpdateResult\"", ((string)(null)), table16, "When ");
+#line hidden
+#line 161
+ testRunner.And("I get the tenant id of the tenant called \"ChildTenant1\" and call it \"ChildTenantI" +
+                        "d\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 162
+ testRunner.And("I get the tenant with the id called \"ChildTenantId\" and call it \"Result\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 163
+ testRunner.Then("the tenant called \"ChildTenant1\" should have the same ID as the tenant called \"Re" +
+                        "sult\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line hidden
+                TechTalk.SpecFlow.Table table17 = new TechTalk.SpecFlow.Table(new string[] {
+                            "Key",
+                            "Value",
+                            "Type"});
+                table17.AddRow(new string[] {
+                            "FirstKey",
+                            "1",
+                            "integer"});
+                table17.AddRow(new string[] {
+                            "SecondKey",
+                            "This is a different string",
+                            "string"});
+                table17.AddRow(new string[] {
+                            "FourthKey",
+                            "2",
+                            "integer"});
+                table17.AddRow(new string[] {
+                            "FifthKey",
+                            "This is a new string",
+                            "string"});
+#line 164
+ testRunner.And("the tenant called \"UpdateResult\" should have the properties", ((string)(null)), table17, "And ");
+#line hidden
+                TechTalk.SpecFlow.Table table18 = new TechTalk.SpecFlow.Table(new string[] {
+                            "Key",
+                            "Value",
+                            "Type"});
+                table18.AddRow(new string[] {
+                            "FirstKey",
+                            "1",
+                            "integer"});
+                table18.AddRow(new string[] {
+                            "SecondKey",
+                            "This is a different string",
+                            "string"});
+                table18.AddRow(new string[] {
+                            "FourthKey",
+                            "2",
+                            "integer"});
+                table18.AddRow(new string[] {
+                            "FifthKey",
+                            "This is a new string",
+                            "string"});
+#line 170
+ testRunner.And("the tenant called \"Result\" should have the properties", ((string)(null)), table18, "And ");
+#line hidden
+            }
+            this.ScenarioCleanup();
+        }
+        
+        [NUnit.Framework.TestAttribute()]
+        [NUnit.Framework.DescriptionAttribute("Rename a child tenant")]
+        public virtual void RenameAChildTenant()
+        {
+            string[] tagsOfScenario = ((string[])(null));
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Rename a child tenant", null, ((string[])(null)));
+#line 177
+this.ScenarioInitialize(scenarioInfo);
+#line hidden
+            bool isScenarioIgnored = default(bool);
+            bool isFeatureIgnored = default(bool);
+            if ((tagsOfScenario != null))
+            {
+                isScenarioIgnored = tagsOfScenario.Where(__entry => __entry != null).Where(__entry => String.Equals(__entry, "ignore", StringComparison.CurrentCultureIgnoreCase)).Any();
+            }
+            if ((this._featureTags != null))
+            {
+                isFeatureIgnored = this._featureTags.Where(__entry => __entry != null).Where(__entry => String.Equals(__entry, "ignore", StringComparison.CurrentCultureIgnoreCase)).Any();
+            }
+            if ((isScenarioIgnored || isFeatureIgnored))
+            {
+                testRunner.SkipScenario();
+            }
+            else
+            {
+                this.ScenarioStart();
+#line 178
+ testRunner.Given("I create a child tenant called \"ChildTenant1\" for the root tenant", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
+#line hidden
+#line 179
+ testRunner.When("I change the name of the tenant called \"ChildTenant1\" to \"NewName\" and call the r" +
+                        "eturned tenant \"UpdateResult\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+#line 180
+ testRunner.And("I get the tenant id of the tenant called \"ChildTenant1\" and call it \"ChildTenantI" +
+                        "d\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 181
+ testRunner.And("I get the tenant with the id called \"ChildTenantId\" and call it \"Result\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 182
+ testRunner.Then("the tenant called \"ChildTenant1\" should have the same ID as the tenant called \"Re" +
+                        "sult\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line hidden
+#line 183
+ testRunner.Then("the tenant called \"ChildTenant1\" should have the same ID as the tenant called \"Re" +
+                        "sult\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line hidden
+            }
+            this.ScenarioCleanup();
+        }
+        
+        [NUnit.Framework.TestAttribute()]
+        [NUnit.Framework.DescriptionAttribute("Create a child of a child")]
+        public virtual void CreateAChildOfAChild()
+        {
+            string[] tagsOfScenario = ((string[])(null));
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Create a child of a child", null, ((string[])(null)));
+#line 185
+this.ScenarioInitialize(scenarioInfo);
+#line hidden
+            bool isScenarioIgnored = default(bool);
+            bool isFeatureIgnored = default(bool);
+            if ((tagsOfScenario != null))
+            {
+                isScenarioIgnored = tagsOfScenario.Where(__entry => __entry != null).Where(__entry => String.Equals(__entry, "ignore", StringComparison.CurrentCultureIgnoreCase)).Any();
+            }
+            if ((this._featureTags != null))
+            {
+                isFeatureIgnored = this._featureTags.Where(__entry => __entry != null).Where(__entry => String.Equals(__entry, "ignore", StringComparison.CurrentCultureIgnoreCase)).Any();
+            }
+            if ((isScenarioIgnored || isFeatureIgnored))
+            {
+                testRunner.SkipScenario();
+            }
+            else
+            {
+                this.ScenarioStart();
+#line 186
+ testRunner.Given("I create a child tenant called \"ChildTenant1\" for the root tenant", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
+#line hidden
+#line 187
  testRunner.And("I create a child tenant called \"ChildTenant2\" for the tenant called \"ChildTenant1" +
                         "\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 78
+#line 188
  testRunner.When("I get the tenant id of the tenant called \"ChildTenant2\" and call it \"ChildTenantI" +
                         "d\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-#line 79
+#line 189
  testRunner.And("I get the tenant with the id called \"ChildTenantId\" and call it \"Result\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 80
+#line 190
  testRunner.Then("the tenant called \"ChildTenant2\" should have the same ID as the tenant called \"Re" +
                         "sult\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
@@ -583,7 +1111,7 @@ this.ScenarioInitialize(scenarioInfo);
         {
             string[] tagsOfScenario = ((string[])(null));
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Get children", null, ((string[])(null)));
-#line 82
+#line 192
 this.ScenarioInitialize(scenarioInfo);
 #line hidden
             bool isScenarioIgnored = default(bool);
@@ -603,46 +1131,46 @@ this.ScenarioInitialize(scenarioInfo);
             else
             {
                 this.ScenarioStart();
-#line 83
+#line 193
  testRunner.Given("I create a child tenant called \"ChildTenant1\" for the root tenant", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
 #line hidden
-#line 84
+#line 194
  testRunner.And("I create a child tenant called \"ChildTenant2\" for the tenant called \"ChildTenant1" +
                         "\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 85
+#line 195
  testRunner.And("I create a child tenant called \"ChildTenant3\" for the tenant called \"ChildTenant1" +
                         "\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 86
+#line 196
  testRunner.And("I create a child tenant called \"ChildTenant4\" for the tenant called \"ChildTenant1" +
                         "\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 87
+#line 197
  testRunner.And("I create a child tenant called \"ChildTenant5\" for the tenant called \"ChildTenant1" +
                         "\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 88
+#line 198
  testRunner.When("I get the tenant id of the tenant called \"ChildTenant1\" and call it \"ChildTenantI" +
                         "d\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-#line 89
+#line 199
  testRunner.And("I get the children of the tenant with the id called \"ChildTenantId\" with maxItems" +
                         " 20 and call them \"Result\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-                TechTalk.SpecFlow.Table table4 = new TechTalk.SpecFlow.Table(new string[] {
+                TechTalk.SpecFlow.Table table19 = new TechTalk.SpecFlow.Table(new string[] {
                             "TenantName"});
-                table4.AddRow(new string[] {
+                table19.AddRow(new string[] {
                             "ChildTenant2"});
-                table4.AddRow(new string[] {
+                table19.AddRow(new string[] {
                             "ChildTenant3"});
-                table4.AddRow(new string[] {
+                table19.AddRow(new string[] {
                             "ChildTenant4"});
-                table4.AddRow(new string[] {
+                table19.AddRow(new string[] {
                             "ChildTenant5"});
-#line 90
+#line 200
  testRunner.Then("the ids of the children called \"Result\" should match the ids of the tenants calle" +
-                        "d", ((string)(null)), table4, "Then ");
+                        "d", ((string)(null)), table19, "Then ");
 #line hidden
             }
             this.ScenarioCleanup();
@@ -654,7 +1182,7 @@ this.ScenarioInitialize(scenarioInfo);
         {
             string[] tagsOfScenario = ((string[])(null));
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Get children with continuation token", null, ((string[])(null)));
-#line 97
+#line 207
 this.ScenarioInitialize(scenarioInfo);
 #line hidden
             bool isScenarioIgnored = default(bool);
@@ -674,56 +1202,56 @@ this.ScenarioInitialize(scenarioInfo);
             else
             {
                 this.ScenarioStart();
-#line 98
+#line 208
  testRunner.Given("I create a child tenant called \"ChildTenant1\" for the root tenant", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
 #line hidden
-#line 99
+#line 209
  testRunner.And("I create a child tenant called \"ChildTenant2\" for the tenant called \"ChildTenant1" +
                         "\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 100
+#line 210
  testRunner.And("I create a child tenant called \"ChildTenant3\" for the tenant called \"ChildTenant1" +
                         "\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 101
+#line 211
  testRunner.And("I create a child tenant called \"ChildTenant4\" for the tenant called \"ChildTenant1" +
                         "\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 102
+#line 212
  testRunner.And("I create a child tenant called \"ChildTenant5\" for the tenant called \"ChildTenant1" +
                         "\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 103
+#line 213
  testRunner.When("I get the tenant id of the tenant called \"ChildTenant1\" and call it \"ChildTenantI" +
                         "d\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-#line 104
+#line 214
  testRunner.And("I get the children of the tenant with the id called \"ChildTenantId\" with maxItems" +
                         " 2 and call them \"Result\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 105
+#line 215
  testRunner.And("I get the children of the tenant with the id called \"ChildTenantId\" with maxItems" +
                         " 20 and continuation token \"Result\" and call them \"Result2\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 106
+#line 216
  testRunner.Then("there should be 2 tenants in \"Result\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
-#line 107
+#line 217
  testRunner.And("there should be 2 tenants in \"Result2\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-                TechTalk.SpecFlow.Table table5 = new TechTalk.SpecFlow.Table(new string[] {
+                TechTalk.SpecFlow.Table table20 = new TechTalk.SpecFlow.Table(new string[] {
                             "TenantName"});
-                table5.AddRow(new string[] {
+                table20.AddRow(new string[] {
                             "ChildTenant5"});
-                table5.AddRow(new string[] {
+                table20.AddRow(new string[] {
                             "ChildTenant4"});
-                table5.AddRow(new string[] {
+                table20.AddRow(new string[] {
                             "ChildTenant3"});
-                table5.AddRow(new string[] {
+                table20.AddRow(new string[] {
                             "ChildTenant2"});
-#line 108
+#line 218
  testRunner.And("the ids of the children called \"Result\" and \"Result2\" should each match 2 of the " +
-                        "ids of the tenants called", ((string)(null)), table5, "And ");
+                        "ids of the tenants called", ((string)(null)), table20, "And ");
 #line hidden
             }
             this.ScenarioCleanup();
@@ -735,7 +1263,7 @@ this.ScenarioInitialize(scenarioInfo);
         {
             string[] tagsOfScenario = ((string[])(null));
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Delete a child", null, ((string[])(null)));
-#line 115
+#line 225
 this.ScenarioInitialize(scenarioInfo);
 #line hidden
             bool isScenarioIgnored = default(bool);
@@ -755,51 +1283,51 @@ this.ScenarioInitialize(scenarioInfo);
             else
             {
                 this.ScenarioStart();
-#line 116
+#line 226
  testRunner.Given("I create a child tenant called \"ChildTenant1\" for the root tenant", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
 #line hidden
-#line 117
+#line 227
  testRunner.And("I create a child tenant called \"ChildTenant2\" for the tenant called \"ChildTenant1" +
                         "\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 118
+#line 228
  testRunner.And("I create a child tenant called \"ChildTenant3\" for the tenant called \"ChildTenant1" +
                         "\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 119
+#line 229
  testRunner.And("I create a child tenant called \"ChildTenant4\" for the tenant called \"ChildTenant1" +
                         "\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 120
+#line 230
  testRunner.And("I create a child tenant called \"ChildTenant5\" for the tenant called \"ChildTenant1" +
                         "\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 121
+#line 231
  testRunner.When("I get the tenant id of the tenant called \"ChildTenant1\" and call it \"ChildTenantI" +
                         "d\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-#line 122
+#line 232
  testRunner.And("I get the tenant id of the tenant called \"ChildTenant3\" and call it \"DeletedChild" +
                         "TenantId\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 123
+#line 233
  testRunner.And("I delete the tenant with the id called \"DeletedChildTenantId\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 124
+#line 234
  testRunner.And("I get the children of the tenant with the id called \"ChildTenantId\" with maxItems" +
                         " 20 and call them \"Result\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-                TechTalk.SpecFlow.Table table6 = new TechTalk.SpecFlow.Table(new string[] {
+                TechTalk.SpecFlow.Table table21 = new TechTalk.SpecFlow.Table(new string[] {
                             "TenantName"});
-                table6.AddRow(new string[] {
+                table21.AddRow(new string[] {
                             "ChildTenant2"});
-                table6.AddRow(new string[] {
+                table21.AddRow(new string[] {
                             "ChildTenant4"});
-                table6.AddRow(new string[] {
+                table21.AddRow(new string[] {
                             "ChildTenant5"});
-#line 125
+#line 235
  testRunner.Then("the ids of the children called \"Result\" should match the ids of the tenants calle" +
-                        "d", ((string)(null)), table6, "Then ");
+                        "d", ((string)(null)), table21, "Then ");
 #line hidden
             }
             this.ScenarioCleanup();

--- a/Solutions/Corvus.Tenancy.Specs/Steps/SqlConnectionSteps.cs
+++ b/Solutions/Corvus.Tenancy.Specs/Steps/SqlConnectionSteps.cs
@@ -45,7 +45,7 @@
                 sqlConfiguration.DisableTenantIdPrefix = true;
             }
 
-            tenantProvider.Root.SetSqlConfiguration(sqlConnectionDefinition, sqlConfiguration);
+            tenantProvider.Root.UpdateProperties(values => values.AddSqlConfiguration(sqlConnectionDefinition, sqlConfiguration));
 
             using SqlConnection sqlConnection = await factory.GetSqlConnectionForTenantAsync(
                 tenantProvider.Root,

--- a/Solutions/Corvus.Tenancy.Specs/Steps/TenantStorageSteps.cs
+++ b/Solutions/Corvus.Tenancy.Specs/Steps/TenantStorageSteps.cs
@@ -143,8 +143,19 @@
             }
         }
 
-        [When("I update the properties of the tenant called \"(.*)\"")]
-        public async Task WhenIUpdateThePropertiesOfTheTenantCalled(string tenantName, Table table)
+        [Given(@"I update the properties of the tenant called ""([^""]*)""")]
+        [When(@"I update the properties of the tenant called ""([^""]*)""")]
+        public async Task GivenIUpdateThePropertiesOfTheTenantCalled(string tenantName, Table table)
+        {
+            await this.WhenIUpdateThePropertiesOfTheTenantCalled(tenantName, null, table).ConfigureAwait(false);
+        }
+
+        [Given("I update the properties of the tenant called \"(.*)\" and call the returned tenant \"(.*)\"")]
+        [When("I update the properties of the tenant called \"(.*)\" and call the returned tenant \"(.*)\"")]
+        public async Task WhenIUpdateThePropertiesOfTheTenantCalled(
+            string tenantName,
+            string? returnedTenantName,
+            Table table)
         {
             ITenant tenant = this.scenarioContext.Get<ITenant>(tenantName);
 
@@ -179,7 +190,53 @@
                 }
             }
 
-            await this.store.UpdateTenantAsync(tenant.Id, properties).ConfigureAwait(false);
+            ITenant updatedTenant = await this.store.UpdateTenantAsync(
+                tenant.Id,
+                propertiesToSetOrAdd: properties).ConfigureAwait(false);
+
+            if (returnedTenantName is string)
+            {
+                this.scenarioContext.Set(updatedTenant, returnedTenantName);
+            }
+        }
+
+        [When(@"I remove the ""(.*)"" property of the tenant called ""(.*)"" and call the returned tenant ""(.*)""")]
+        public async Task WhenIRemoveThePropertyOfTheTenantCalledAsync(
+            string propertyName,
+            string tenantName,
+            string returnedTenantName)
+        {
+            ITenant tenant = this.scenarioContext.Get<ITenant>(tenantName);
+            ITenant updatedTenant = await this.store.UpdateTenantAsync(
+                tenant.Id,
+                propertiesToRemove: new[] { propertyName })
+                .ConfigureAwait(false);
+            this.scenarioContext.Set(updatedTenant, returnedTenantName);
+        }
+
+        [When(@"I update the properties of the tenant called ""(.*)"" and remove the ""(.*)"" property and call the returned tenant ""(.*)""")]
+        public async Task WhenIUpdateThePropertiesOfTheTenantCalledAndRemoveThePropertyAndCallTheReturnedTenant(
+            string tenantName,
+            string propertyToRemove,
+            string returnedTenantName,
+            Table table)
+        {
+            await this.WhenIUpdateThePropertiesOfTheTenantCalled(tenantName, null, table).ConfigureAwait(false);
+            await this.WhenIRemoveThePropertyOfTheTenantCalledAsync(propertyToRemove, tenantName, returnedTenantName).ConfigureAwait(false);
+        }
+
+        [When(@"I change the name of the tenant called ""(.*)"" to ""(.*)"" and call the returned tenant ""(.*)""")]
+        public async Task WhenIChangeTheNameOfTheTenantCalledToAndCallTheReturnedTenantAsync(
+            string tenantName,
+            string newName,
+            string returnedTenantName)
+        {
+            ITenant tenant = this.scenarioContext.Get<ITenant>(tenantName);
+            ITenant updatedTenant = await this.store.UpdateTenantAsync(
+                tenant.Id,
+                name: newName).ConfigureAwait(false);
+
+            this.scenarioContext.Set(updatedTenant, returnedTenantName);
         }
 
         [When("I get the children of the tenant with the id called \"(.*)\" with maxItems (.*) and call them \"(.*)\"")]

--- a/Solutions/Corvus.Tenancy.Storage.Azure.Blob/Corvus.Tenancy.Storage.Azure.Blob.csproj
+++ b/Solutions/Corvus.Tenancy.Storage.Azure.Blob/Corvus.Tenancy.Storage.Azure.Blob.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="$(EndjinProjectPropsPath)" />
+
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <RootNamespace />
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
@@ -15,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Corvus.Extensions" Version="0.8.0" />
-    <PackageReference Include="Endjin.RecommendedPractices" Version="0.1.0">
+    <PackageReference Include="Endjin.RecommendedPractices" Version="0.2.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Solutions/Corvus.Tenancy.Storage.Azure.Blob/Corvus.Tenancy.Storage.Azure.Blob.csproj
+++ b/Solutions/Corvus.Tenancy.Storage.Azure.Blob/Corvus.Tenancy.Storage.Azure.Blob.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="$(EndjinProjectPropsPath)" />
+  <Import Project="$(EndjinProjectPropsPath)" Condition="$(EndjinProjectPropsPath) != ''" />
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Corvus.Extensions" Version="0.8.0" />
-    <PackageReference Include="Endjin.RecommendedPractices" Version="0.2.1">
+    <PackageReference Include="Endjin.RecommendedPractices" Version="0.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Solutions/Corvus.Tenancy.Storage.Azure.Blob/Corvus/Tenancy/Storage/Azure/TenantProviderBlobStore.cs
+++ b/Solutions/Corvus.Tenancy.Storage.Azure.Blob/Corvus/Tenancy/Storage/Azure/TenantProviderBlobStore.cs
@@ -14,6 +14,7 @@ namespace Corvus.Tenancy
     using Corvus.Azure.Storage.Tenancy;
     using Corvus.Extensions;
     using Corvus.Extensions.Json;
+    using Corvus.Json;
     using Corvus.Tenancy.Exceptions;
     using Microsoft.Azure.Storage;
     using Microsoft.Azure.Storage.Blob;
@@ -150,7 +151,7 @@ namespace Corvus.Tenancy
 
                 IPropertyBag updatedProperties = this.propertyBagFactory.CreateModified(
                     tenant.Properties,
-                    propertiesToSetOrAdd?.NonNullToNullable(),
+                    propertiesToSetOrAdd,
                     propertiesToRemove);
 
                 var updatedTenant = new Tenant(
@@ -199,7 +200,7 @@ namespace Corvus.Tenancy
                 // to support the tenant blob store provider. We would expect this to be overridden by clients that wanted to
                 // establish their own settings.
                 BlobStorageConfiguration tenancyStorageConfiguration = parentTenant.GetBlobStorageConfiguration(ContainerDefinition);
-                IPropertyBag childProperties = this.propertyBagFactory.CreateWithNonNullValues(values =>
+                IPropertyBag childProperties = this.propertyBagFactory.Create(values =>
                     values.AddBlobStorageConfiguration(ContainerDefinition, tenancyStorageConfiguration));
                 var child = new Tenant(
                     parentTenantId.CreateChildId(wellKnownChildTenantGuid),

--- a/Solutions/Corvus.Tenancy.Storage.Azure.Blob/Microsoft/Extensions/DependencyInjection/TenantProviderBlobStoreServiceCollectionExtensions.cs
+++ b/Solutions/Corvus.Tenancy.Storage.Azure.Blob/Microsoft/Extensions/DependencyInjection/TenantProviderBlobStoreServiceCollectionExtensions.cs
@@ -40,14 +40,18 @@ namespace Microsoft.Extensions.DependencyInjection
                 BlobStorageConfiguration rootTenantStorageConfig = getRootTenantStorageConfiguration(sp);
                 RootTenant rootTenant = sp.GetRequiredService<RootTenant>();
 
-                rootTenant.SetBlobStorageConfiguration(TenantProviderBlobStore.ContainerDefinition, rootTenantStorageConfig);
+                rootTenant.UpdateProperties(
+                    values => values.AddBlobStorageConfiguration(
+                        TenantProviderBlobStore.ContainerDefinition, rootTenantStorageConfig));
 
                 ITenantCloudBlobContainerFactory tenantCloudBlobContainerFactory = sp.GetRequiredService<ITenantCloudBlobContainerFactory>();
                 IJsonSerializerSettingsProvider serializerSettingsProvider = sp.GetRequiredService<IJsonSerializerSettingsProvider>();
+                IPropertyBagFactory propertyBagFactory = sp.GetRequiredService<IPropertyBagFactory>();
 
-                return new TenantProviderBlobStore(sp, rootTenant, tenantCloudBlobContainerFactory, serializerSettingsProvider);
+                return new TenantProviderBlobStore(rootTenant, propertyBagFactory, tenantCloudBlobContainerFactory, serializerSettingsProvider);
             });
 
+            services.AddSingleton<ITenantStore>(sp => sp.GetRequiredService<TenantProviderBlobStore>());
             services.AddSingleton<ITenantProvider>(sp => sp.GetRequiredService<TenantProviderBlobStore>());
             return services;
         }

--- a/Solutions/Corvus.Tenancy.Storage.Azure.Blob/Microsoft/Extensions/DependencyInjection/TenantProviderBlobStoreServiceCollectionExtensions.cs
+++ b/Solutions/Corvus.Tenancy.Storage.Azure.Blob/Microsoft/Extensions/DependencyInjection/TenantProviderBlobStoreServiceCollectionExtensions.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Extensions.DependencyInjection
     using System.Linq;
     using Corvus.Azure.Storage.Tenancy;
     using Corvus.Extensions.Json;
+    using Corvus.Json;
     using Corvus.Tenancy;
 
     /// <summary>


### PR DESCRIPTION
We were using the Json.NET-specific `PropertyBag` type as part of `ITenant`, binding tenancy to one particular serialization implementation. Since we are contemplating a move to `System.Text.Json`, this is an unhelpful dependency.

In any case, that old `PropertyBag` caused some challenges with deserialization. The update to `IPropertyBag` makes it possible for `Corvus.ContentHandling` to support constructor-based deserialization, and to reduce the need for code working with property bags to pass JSON serialization settings around all over the place.