### PR TITLE
Detect and remove faulted container creation tasks from the cache

### DIFF
--- a/Solutions/Corvus.Azure.Cosmos.Tenancy/Corvus/Azure/Cosmos/Tenancy/Internal/TenantCosmosContainerFactory.cs
+++ b/Solutions/Corvus.Azure.Cosmos.Tenancy/Corvus/Azure/Cosmos/Tenancy/Internal/TenantCosmosContainerFactory.cs
@@ -6,7 +6,6 @@ namespace Corvus.Azure.Cosmos.Tenancy.Internal
 {
     using System;
     using System.Collections.Concurrent;
-    using System.Threading;
     using System.Threading.Tasks;
     using Corvus.Extensions.Cosmos;
     using Corvus.Tenancy;


### PR DESCRIPTION
The code we have for creating tenanted Cosmos containers intends to cache the resultant containers. However, it actually caches the Task representing the creation process. This means that if the creation task fails, we end up caching a faulted task. All future requests for the container will receive this faulted task, making this unrecoverable.

In order to deal with this, we need to detect if the cache contains a faulted task and attempt to remove then re-add the creation task.

In conjunction with this, consumers will need to implement their own error handling and retry logic - but they should already have been doing this, even though the retry aspect wouldn't have worked.
