### PR TITLE
Fix names in debugger display attribute on Tenant class.

### DIFF
--- a/Solutions/Corvus.Tenancy.Abstractions/Corvus/Tenancy/Tenant.cs
+++ b/Solutions/Corvus.Tenancy.Abstractions/Corvus/Tenancy/Tenant.cs
@@ -10,7 +10,7 @@ namespace Corvus.Tenancy
     /// <summary>
     /// Describes a tenant in a multitenanted system.
     /// </summary>
-    [DebuggerDisplay("{name} ({id})")]
+    [DebuggerDisplay("{Name} ({Id})")]
     public class Tenant : ITenant
     {
         /// <summary>


### PR DESCRIPTION
A previous PR replaced the `id` and `name` fields on the `Tenant` class with properties. Unfortunately, the corresponding change was not made to the `DebuggerDisplay` attribute on that class, so this PR brings the two in line and enables the attribute to work correctly.