### PR TITLE
Reintroduce support for netstandard2.0.

### DIFF
--- a/Solutions/Corvus.Azure.Cosmos.Tenancy/Corvus.Azure.Cosmos.Tenancy.csproj
+++ b/Solutions/Corvus.Azure.Cosmos.Tenancy/Corvus.Azure.Cosmos.Tenancy.csproj
@@ -3,7 +3,7 @@
   <Import Project="$(EndjinProjectPropsPath)" Condition="$(EndjinProjectPropsPath) != ''" />
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/Solutions/Corvus.Azure.Gremlin.Tenancy/Corvus.Azure.Gremlin.Tenancy.csproj
+++ b/Solutions/Corvus.Azure.Gremlin.Tenancy/Corvus.Azure.Gremlin.Tenancy.csproj
@@ -3,7 +3,7 @@
   <Import Project="$(EndjinProjectPropsPath)" Condition="$(EndjinProjectPropsPath) != ''" />
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/Solutions/Corvus.Azure.Storage.Tenancy/Corvus.Azure.Storage.Tenancy.csproj
+++ b/Solutions/Corvus.Azure.Storage.Tenancy/Corvus.Azure.Storage.Tenancy.csproj
@@ -3,7 +3,7 @@
   <Import Project="$(EndjinProjectPropsPath)" Condition="$(EndjinProjectPropsPath) != ''" />
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/Solutions/Corvus.Sql.Tenancy/Corvus.Sql.Tenancy.csproj
+++ b/Solutions/Corvus.Sql.Tenancy/Corvus.Sql.Tenancy.csproj
@@ -3,7 +3,7 @@
   <Import Project="$(EndjinProjectPropsPath)" Condition="$(EndjinProjectPropsPath) != ''" />
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/Solutions/Corvus.Tenancy.Abstractions/Corvus.Tenancy.Abstractions.csproj
+++ b/Solutions/Corvus.Tenancy.Abstractions/Corvus.Tenancy.Abstractions.csproj
@@ -3,7 +3,7 @@
   <Import Project="$(EndjinProjectPropsPath)" Condition="$(EndjinProjectPropsPath) != ''" />
   
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
@@ -28,4 +28,8 @@
     </PackageReference>
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.1.1" />
+  </ItemGroup>
+  
 </Project>

--- a/Solutions/Corvus.Tenancy.Storage.Azure.Blob/Corvus.Tenancy.Storage.Azure.Blob.csproj
+++ b/Solutions/Corvus.Tenancy.Storage.Azure.Blob/Corvus.Tenancy.Storage.Azure.Blob.csproj
@@ -3,7 +3,7 @@
   <Import Project="$(EndjinProjectPropsPath)" Condition="$(EndjinProjectPropsPath) != ''" />
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 


### PR DESCRIPTION
This was inadvertently removed in December. We want to retain netstandard2.0 support for now, as netstandard2.1 is not supported by .NET Framework.