### PR TITLE
Make types supporting v2 legacy config public

### DIFF
--- a/Solutions/Corvus.Storage.Azure.BlobStorage.Tenancy/AssemblyAttributes.cs
+++ b/Solutions/Corvus.Storage.Azure.BlobStorage.Tenancy/AssemblyAttributes.cs
@@ -1,7 +1,0 @@
-﻿// <copyright file="AssemblyAttributes.cs" company="Endjin Limited">
-// Copyright (c) Endjin Limited. All rights reserved.
-// </copyright>
-
-using System.Runtime.CompilerServices;
-
-[assembly: InternalsVisibleTo("Corvus.Tenancy.Specs")]

--- a/Solutions/Corvus.Storage.Azure.BlobStorage.Tenancy/Corvus/Storage/Azure/BlobStorage/Tenancy/Internal/BlobContainerSourceWithTenantLegacyTransition.cs
+++ b/Solutions/Corvus.Storage.Azure.BlobStorage.Tenancy/Corvus/Storage/Azure/BlobStorage/Tenancy/Internal/BlobContainerSourceWithTenantLegacyTransition.cs
@@ -10,6 +10,7 @@ namespace Corvus.Storage.Azure.BlobStorage.Tenancy.Internal
     using System.Text;
     using System.Threading.Tasks;
 
+    using Corvus.Storage.Azure.BlobStorage.Tenancy;
     using Corvus.Tenancy;
 
     using global::Azure.Storage.Blobs;
@@ -64,9 +65,9 @@ namespace Corvus.Storage.Azure.BlobStorage.Tenancy.Internal
                     v3Configuration = v3Configuration.ForContainer(hashedTenantedContainerName);
                 }
             }
-            else if (tenant.Properties.TryGet(v2ConfigurationKey, out LegacyBlobStorageConfiguration legacyConfiguration))
+            else if (tenant.Properties.TryGet(v2ConfigurationKey, out LegacyV2BlobStorageConfiguration legacyConfiguration))
             {
-                v3Configuration = LegacyConfigurationConverter.FromV2(legacyConfiguration);
+                v3Configuration = LegacyConfigurationConverter.FromV2ToV3(legacyConfiguration);
                 string rawContainerName = string.IsNullOrWhiteSpace(containerName)
                     ? legacyConfiguration.Container ?? throw new InvalidOperationException($"When the configuration does not specify a Container, you must supply a {containerName}")
                     : containerName;
@@ -75,8 +76,8 @@ namespace Corvus.Storage.Azure.BlobStorage.Tenancy.Internal
                 v3Configuration = v3Configuration.ForContainer(hashedTenantedContainerName);
                 publicAccessType = legacyConfiguration.AccessType switch
                 {
-                    LegacyBlobContainerPublicAccessType.Blob => PublicAccessType.Blob,
-                    LegacyBlobContainerPublicAccessType.Container => PublicAccessType.BlobContainer,
+                    LegacyV2BlobContainerPublicAccessType.Blob => PublicAccessType.Blob,
+                    LegacyV2BlobContainerPublicAccessType.Container => PublicAccessType.BlobContainer,
                     _ => PublicAccessType.None,
                 };
             }
@@ -117,7 +118,7 @@ namespace Corvus.Storage.Azure.BlobStorage.Tenancy.Internal
                 return null;
             }
 
-            if (!tenant.Properties.TryGet(v2ConfigurationKey, out LegacyBlobStorageConfiguration legacyConfiguration))
+            if (!tenant.Properties.TryGet(v2ConfigurationKey, out LegacyV2BlobStorageConfiguration legacyConfiguration))
             {
                 throw new InvalidOperationException("Nope");
             }
@@ -145,8 +146,8 @@ namespace Corvus.Storage.Azure.BlobStorage.Tenancy.Internal
                 BlobContainerConfiguration thisConfig = v3Configuration.ForContainer(hashedTenantedContainerName);
                 PublicAccessType publicAccessType = legacyConfiguration.AccessType switch
                 {
-                    LegacyBlobContainerPublicAccessType.Blob => PublicAccessType.Blob,
-                    LegacyBlobContainerPublicAccessType.Container => PublicAccessType.BlobContainer,
+                    LegacyV2BlobContainerPublicAccessType.Blob => PublicAccessType.Blob,
+                    LegacyV2BlobContainerPublicAccessType.Container => PublicAccessType.BlobContainer,
                     _ => PublicAccessType.None,
                 };
 

--- a/Solutions/Corvus.Storage.Azure.BlobStorage.Tenancy/Corvus/Storage/Azure/BlobStorage/Tenancy/LegacyConfigurationConverter.cs
+++ b/Solutions/Corvus.Storage.Azure.BlobStorage.Tenancy/Corvus/Storage/Azure/BlobStorage/Tenancy/LegacyConfigurationConverter.cs
@@ -2,7 +2,7 @@
 // Copyright (c) Endjin Limited. All rights reserved.
 // </copyright>
 
-namespace Corvus.Storage.Azure.BlobStorage.Tenancy.Internal
+namespace Corvus.Storage.Azure.BlobStorage.Tenancy
 {
     using System;
 
@@ -11,18 +11,18 @@ namespace Corvus.Storage.Azure.BlobStorage.Tenancy.Internal
     /// <summary>
     /// Converts legacy v2 configuration into the v3 format.
     /// </summary>
-    internal static class LegacyConfigurationConverter
+    public static class LegacyConfigurationConverter
     {
         /// <summary>
         /// Converts legacy V2-era configuration settings into the new format introduced in V3.
         /// </summary>
         /// <param name="legacyConfiguration">The old settings to convert.</param>
         /// <returns>The converted settings.</returns>
-        public static BlobContainerConfiguration FromV2(LegacyBlobStorageConfiguration legacyConfiguration)
+        public static BlobContainerConfiguration FromV2ToV3(LegacyV2BlobStorageConfiguration legacyConfiguration)
         {
             bool isDeveloperStorage =
-                (legacyConfiguration.AccountName == "UseDevelopmentStorage=true") ||
-                (legacyConfiguration.AccountName == null);
+                legacyConfiguration.AccountName == "UseDevelopmentStorage=true" ||
+                legacyConfiguration.AccountName == null;
 
             if (isDeveloperStorage)
             {
@@ -49,7 +49,7 @@ namespace Corvus.Storage.Azure.BlobStorage.Tenancy.Internal
         }
 
         private static KeyVaultSecretConfiguration? GetAccessKeyInKeyVaultSecretConfigurationIfApplicable(
-            LegacyBlobStorageConfiguration legacyConfiguration)
+            LegacyV2BlobStorageConfiguration legacyConfiguration)
         {
             return legacyConfiguration.KeyVaultName is null
                 ? null
@@ -57,7 +57,7 @@ namespace Corvus.Storage.Azure.BlobStorage.Tenancy.Internal
                 {
                     VaultName = legacyConfiguration.KeyVaultName,
                     SecretName = legacyConfiguration.AccountKeySecretName
-                        ?? throw new InvalidOperationException($"If {nameof(LegacyBlobStorageConfiguration.KeyVaultName)} is set in legacy configuration, {nameof(LegacyBlobStorageConfiguration.AccountKeySecretName)} must also be set"),
+                        ?? throw new InvalidOperationException($"If {nameof(LegacyV2BlobStorageConfiguration.KeyVaultName)} is set in legacy configuration, {nameof(LegacyV2BlobStorageConfiguration.AccountKeySecretName)} must also be set"),
                 };
         }
     }

--- a/Solutions/Corvus.Storage.Azure.BlobStorage.Tenancy/Corvus/Storage/Azure/BlobStorage/Tenancy/LegacyV2BlobContainerPublicAccessType.cs
+++ b/Solutions/Corvus.Storage.Azure.BlobStorage.Tenancy/Corvus/Storage/Azure/BlobStorage/Tenancy/LegacyV2BlobContainerPublicAccessType.cs
@@ -1,8 +1,8 @@
-﻿// <copyright file="LegacyBlobContainerPublicAccessType.cs" company="Endjin Limited">
+﻿// <copyright file="LegacyV2BlobContainerPublicAccessType.cs" company="Endjin Limited">
 // Copyright (c) Endjin Limited. All rights reserved.
 // </copyright>
 
-namespace Corvus.Storage.Azure.BlobStorage.Tenancy.Internal
+namespace Corvus.Storage.Azure.BlobStorage.Tenancy
 {
     /// <summary>
     /// Identical to the Azure Storage SDK v11's <c>BlobContainerPublicAccessType</c> type. This
@@ -10,7 +10,7 @@ namespace Corvus.Storage.Azure.BlobStorage.Tenancy.Internal
     /// format without imposing a dependency on the old v2 components, or on the old Azure Storage
     /// SDK.
     /// </summary>
-    internal enum LegacyBlobContainerPublicAccessType
+    public enum LegacyV2BlobContainerPublicAccessType
     {
         /// <summary>
         /// No public access. Only the account owner can read resources in this container.

--- a/Solutions/Corvus.Storage.Azure.BlobStorage.Tenancy/Corvus/Storage/Azure/BlobStorage/Tenancy/LegacyV2BlobStorageConfiguration.cs
+++ b/Solutions/Corvus.Storage.Azure.BlobStorage.Tenancy/Corvus/Storage/Azure/BlobStorage/Tenancy/LegacyV2BlobStorageConfiguration.cs
@@ -1,16 +1,14 @@
-﻿// <copyright file="LegacyBlobStorageConfiguration.cs" company="Endjin Limited">
+﻿// <copyright file="LegacyV2BlobStorageConfiguration.cs" company="Endjin Limited">
 // Copyright (c) Endjin Limited. All rights reserved.
 // </copyright>
 
-namespace Corvus.Storage.Azure.BlobStorage.Tenancy.Internal
+namespace Corvus.Storage.Azure.BlobStorage.Tenancy
 {
-    using Corvus.Tenancy;
-
     /// <summary>
     /// Enables this project to read configuration in the legacy v2 <c>BlobStorageConfiguration</c>
     /// format without imposing a dependency on the old v2 components.
     /// </summary>
-    internal class LegacyBlobStorageConfiguration
+    public class LegacyV2BlobStorageConfiguration
     {
         /// <summary>
         /// Gets or sets the account name.
@@ -56,7 +54,7 @@ namespace Corvus.Storage.Azure.BlobStorage.Tenancy.Internal
         /// containers exist" step for each tenant.)
         /// </para>
         /// </remarks>
-        public LegacyBlobContainerPublicAccessType? AccessType { get; set; }
+        public LegacyV2BlobContainerPublicAccessType? AccessType { get; set; }
 
         /// <summary>
         /// Gets or sets the key value name.

--- a/Solutions/Corvus.Tenancy.Specs/LegacyConfigurationTransformationStepDefinitions.cs
+++ b/Solutions/Corvus.Tenancy.Specs/LegacyConfigurationTransformationStepDefinitions.cs
@@ -10,7 +10,7 @@ namespace Corvus.Tenancy.Specs
     using System.Reflection;
 
     using Corvus.Storage.Azure.BlobStorage;
-    using Corvus.Storage.Azure.BlobStorage.Tenancy.Internal;
+    using Corvus.Storage.Azure.BlobStorage.Tenancy;
 
     using FluentAssertions;
 
@@ -20,19 +20,19 @@ namespace Corvus.Tenancy.Specs
     [Binding]
     public class LegacyConfigurationTransformationStepDefinitions
     {
-        private LegacyBlobStorageConfiguration legacyConfiguration = new ();
+        private LegacyV2BlobStorageConfiguration legacyConfiguration = new ();
         private BlobContainerConfiguration? resultingConfiguration;
 
         [Given(@"legacy v2 configuration with these properties")]
         public void GivenLegacyVConfigurationWithTheseProperties(Table table)
         {
-            this.legacyConfiguration = table.CreateInstance<LegacyBlobStorageConfiguration>();
+            this.legacyConfiguration = table.CreateInstance<LegacyV2BlobStorageConfiguration>();
         }
 
         [When(@"the legacy v2 configuration is converted to the new format")]
         public void WhenTheLegacyVConfigurationIsConvertedToTheNewFormat()
         {
-            this.resultingConfiguration = LegacyConfigurationConverter.FromV2(this.legacyConfiguration);
+            this.resultingConfiguration = LegacyConfigurationConverter.FromV2ToV3(this.legacyConfiguration);
         }
 
         [Then(@"the resulting BlobContainerConfiguration has these properties")]


### PR DESCRIPTION
Services transitioning from v2 to v3 often need to be able to process v2 config, so it's useful for these types to be available.