### PR TITLE
Add tenanted name helper (#385)

### DIFF
--- a/Solutions/Corvus.Storage.Azure.BlobStorage.Tenancy/Corvus.Storage.Azure.BlobStorage.Tenancy.csproj
+++ b/Solutions/Corvus.Storage.Azure.BlobStorage.Tenancy/Corvus.Storage.Azure.BlobStorage.Tenancy.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Corvus.Storage.Azure.BlobStorage" Version="0.1.0-preview.10" />
+    <PackageReference Include="Corvus.Storage.Azure.BlobStorage" Version="1.0.0" />
     <PackageReference Include="Endjin.RecommendedPractices" Version="1.3.0-PullRequest0026.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Solutions/Corvus.Storage.Azure.BlobStorage.Tenancy/Corvus/Storage/Azure/BlobStorage/Tenancy/AzureBlobStorageNameHelper.cs
+++ b/Solutions/Corvus.Storage.Azure.BlobStorage.Tenancy/Corvus/Storage/Azure/BlobStorage/Tenancy/AzureBlobStorageNameHelper.cs
@@ -6,7 +6,6 @@ namespace Corvus.Storage.Azure.BlobStorage.Tenancy
 {
     using System;
     using System.Security.Cryptography;
-    using System.Text;
 
     using Corvus.Tenancy;
 
@@ -21,10 +20,9 @@ namespace Corvus.Storage.Azure.BlobStorage.Tenancy
     /// name and converting it into a name that's guaranteed to be safe to use. This class provides
     /// helper methods to do that.
     /// </remarks>
+    [Obsolete("This just calls AzureStorageBlobContainerNaming.HashAndEncodeBlobContainerName in the Corvus.Storage library. Use AzureStorageBlobTenantedContainerNaming if you require tenanted name generation")]
     public static class AzureBlobStorageNameHelper
     {
-        private static readonly Lazy<SHA1> HashProvider = new (() => SHA1.Create());
-
         /// <summary>
         /// Make a plain text name safe to use as an Azure storage blob container name.
         /// </summary>
@@ -32,9 +30,7 @@ namespace Corvus.Storage.Azure.BlobStorage.Tenancy
         /// <returns>The encoded name.</returns>
         public static string HashAndEncodeBlobContainerName(string containerName)
         {
-            byte[] byteContents = Encoding.UTF8.GetBytes(containerName);
-            byte[] hashedBytes = HashProvider.Value.ComputeHash(byteContents);
-            return TenantExtensions.ByteArrayToHexViaLookup32(hashedBytes);
+            return AzureStorageBlobContainerNaming.HashAndEncodeBlobContainerName(containerName);
         }
     }
 }

--- a/Solutions/Corvus.Storage.Azure.BlobStorage.Tenancy/Corvus/Storage/Azure/BlobStorage/Tenancy/AzureStorageBlobTenantedContainerNaming.cs
+++ b/Solutions/Corvus.Storage.Azure.BlobStorage.Tenancy/Corvus/Storage/Azure/BlobStorage/Tenancy/AzureStorageBlobTenantedContainerNaming.cs
@@ -1,0 +1,45 @@
+﻿// <copyright file="AzureStorageBlobTenantedContainerNaming.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+namespace Corvus.Storage.Azure.BlobStorage.Tenancy
+{
+    using Corvus.Tenancy;
+
+    /// <summary>
+    /// Converts plain text names for Azure Blob Storage container into tenant-specific names and,
+    /// if required, into hashed names that meet Azure Blob Storage's naming requirements for
+    /// tenants while still being unique.
+    /// </summary>
+    /// <remarks>
+    /// There are various restrictions on blob container names in Azure storage. For example, a
+    /// name can start with a letter or a number and can be a maximum of 63 characters long, and so
+    /// on. As a result, it's desirable to have a mechanism for taking an "ideal world" container
+    /// name and converting it into a name that's guaranteed to be safe to use. This class meets
+    /// those requirements.
+    /// </remarks>
+    public static class AzureStorageBlobTenantedContainerNaming
+    {
+        /// <summary>
+        /// Make a container name safe to use as an Azure storage blob container name, and which
+        /// is unique for this combination of tenant and logical container name.
+        /// </summary>
+        /// <param name="tenant">The tenant for which to generate a name.</param>
+        /// <param name="containerName">The plain text name for the blob container.</param>
+        /// <returns>The encoded name.</returns>
+        public static string GetHashedTenantedBlobContainerNameFor(ITenant tenant, string containerName)
+        {
+            string tenantedUnhashedContainerName = GetTenantedLogicalBlobContainerNameFor(tenant, containerName);
+            return AzureStorageBlobContainerNaming.HashAndEncodeBlobContainerName(tenantedUnhashedContainerName);
+        }
+
+        /// <summary>
+        /// Create a tenant-specific logical name for an Azure storage blob container name.
+        /// </summary>
+        /// <param name="tenant">The tenant for which to generate a name.</param>
+        /// <param name="containerName">The plain text name for the blob container.</param>
+        /// <returns>The encoded name.</returns>
+        public static string GetTenantedLogicalBlobContainerNameFor(ITenant tenant, string containerName)
+            => $"{tenant.Id.ToLowerInvariant()}-{containerName}";
+    }
+}

--- a/Solutions/Corvus.Storage.Azure.Cosmos.Tenancy/Corvus.Storage.Azure.Cosmos.Tenancy.csproj
+++ b/Solutions/Corvus.Storage.Azure.Cosmos.Tenancy/Corvus.Storage.Azure.Cosmos.Tenancy.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Corvus.Storage.Azure.Cosmos" Version="0.1.0-preview.10" />
+    <PackageReference Include="Corvus.Storage.Azure.Cosmos" Version="1.0.0" />
     <PackageReference Include="Endjin.RecommendedPractices" Version="1.3.0-PullRequest0026.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Solutions/Corvus.Tenancy.Abstractions/Corvus/Tenancy/ITenant.cs
+++ b/Solutions/Corvus.Tenancy.Abstractions/Corvus/Tenancy/ITenant.cs
@@ -44,9 +44,9 @@ namespace Corvus.Tenancy
         IPropertyBag Properties { get; }
 
         /// <summary>
-        /// Gets or sets the ETag of the tenant.
+        /// Gets the ETag of the tenant.
         /// </summary>
-        string? ETag { get; set; }
+        string? ETag { get; }
 
         /// <summary>
         /// Gets the content type for the <c>ContentFactory</c> pattern.

--- a/Solutions/Corvus.Tenancy.Specs/BlobContainerNamingStepDefinitions.cs
+++ b/Solutions/Corvus.Tenancy.Specs/BlobContainerNamingStepDefinitions.cs
@@ -1,0 +1,91 @@
+// <copyright file="BlobContainerNamingStepDefinitions.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+namespace Corvus.Tenancy.Specs
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Corvus.Json;
+    using Corvus.Storage.Azure.BlobStorage.Tenancy;
+    using Corvus.Tenancy.Internal;
+
+    using Microsoft.Extensions.DependencyInjection;
+
+    using NUnit.Framework;
+
+    using TechTalk.SpecFlow;
+
+    [Binding]
+    public sealed class BlobContainerNamingStepDefinitions : IDisposable
+    {
+        private readonly Dictionary<string, ITenant> tenants = new ();
+        private readonly Dictionary<string, string> physicalContainerNames = new ();
+        private readonly ServiceProvider serviceProvider;
+        private readonly IPropertyBagFactory propertyBagFactory;
+
+        public BlobContainerNamingStepDefinitions()
+        {
+            ServiceCollection services = new ();
+            services.AddRequiredTenancyServices();
+            this.serviceProvider = services.BuildServiceProvider();
+
+            this.propertyBagFactory = this.serviceProvider.GetRequiredService<IPropertyBagFactory>();
+        }
+
+        public void Dispose()
+        {
+            this.serviceProvider.Dispose();
+        }
+
+        [Given("a tenant labelled '([^']*)'")]
+        public void GivenATenantLabelled(string tenantLabel)
+        {
+            this.GivenATenantLabelledWithId(tenantLabel, Guid.NewGuid().ToString("N"));
+        }
+
+        [Given("a tenant labelled '([^']*)' with id '([^']*)'")]
+        public void GivenATenantLabelledWithId(string tenantLabel, string tenantId)
+        {
+            this.tenants.Add(
+                tenantLabel,
+                new Tenant(tenantId, tenantLabel, this.propertyBagFactory.Create(PropertyBagValues.Empty)));
+        }
+
+        [When("I get a blob container for tenant '([^']*)' with a logical name of '([^']*)' and label the result '([^']*)'")]
+        public void WhenIGetABlobContainerForTenantWithALogicalNameOfAndLabelTheResult(
+            string tenantLabel, string logicalContainerName, string resultLabel)
+        {
+            ITenant tenant = this.tenants[tenantLabel];
+            this.physicalContainerNames.Add(
+                resultLabel,
+                AzureStorageBlobTenantedContainerNaming.GetHashedTenantedBlobContainerNameFor(tenant, logicalContainerName));
+        }
+
+        [Then("the returned container names '([^']*)' and '([^']*)' are different")]
+        public void ThenTheReturnedContainerNamesAndAreDifferent(string resultLabel1, string resultLabel2)
+        {
+            string result1 = this.physicalContainerNames[resultLabel1];
+            string result2 = this.physicalContainerNames[resultLabel2];
+
+            Assert.AreNotEqual(result1, result2);
+        }
+
+        [Then("the returned container names '([^']*)' and '([^']*)' are the same")]
+        public void ThenTheReturnedContainerNamesAndAreTheSame(string resultLabel1, string resultLabel2)
+        {
+            string result1 = this.physicalContainerNames[resultLabel1];
+            string result2 = this.physicalContainerNames[resultLabel2];
+
+            Assert.AreEqual(result1, result2);
+        }
+
+        [Then("the name returned container name '([^']*)' should be '([^']*)'")]
+        public void ThenTheNameReturnedContainerNameShouldBe(string resultLabel, string expectedResult)
+        {
+            string result = this.physicalContainerNames[resultLabel];
+            Assert.AreEqual(expectedResult, result);
+        }
+    }
+}

--- a/Solutions/Corvus.Tenancy.Specs/Corvus.Tenancy.Specs.csproj
+++ b/Solutions/Corvus.Tenancy.Specs/Corvus.Tenancy.Specs.csproj
@@ -57,10 +57,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="6.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="[3.1.*,)" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="[3.1.*,)" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[3.1.*,)" />
-    <PackageReference Include="Corvus.Testing.SpecFlow.NUnit" Version="1.4.6" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="[6.0.*,)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="[6.0.*,)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[6.0.*,)" />
+    <PackageReference Include="Corvus.Testing.SpecFlow.NUnit" Version="1.4.7" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Corvus.Azure.Cosmos.Tenancy\Corvus.Azure.Cosmos.Tenancy.csproj" />

--- a/Solutions/Corvus.Tenancy.Specs/Features/BlobStorage/BlobContainerNaming.feature
+++ b/Solutions/Corvus.Tenancy.Specs/Features/BlobStorage/BlobContainerNaming.feature
@@ -1,0 +1,37 @@
+﻿Feature: BlobContainerNaming
+    As a developer using tenanted Blob Storage
+    In order to separate tenant data even when multiple tenants are sharing an Azure Storage Account
+    I need to be able to generate tenanted names that meet Azure Storage's container constraints, and which are unique
+
+Scenario: Same tenant different logical names
+    Given a tenant labelled 't1'
+    When I get a blob container for tenant 't1' with a logical name of 'c1' and label the result 'n1'
+    And I get a blob container for tenant 't1' with a logical name of 'c2' and label the result 'n2'
+    Then the returned container names 'n1' and 'n2' are different
+
+Scenario: Same logical name different tenants
+    Given a tenant labelled 't1'
+    And a tenant labelled 't2'
+    When I get a blob container for tenant 't1' with a logical name of 'c1' and label the result 'n1'
+    And I get a blob container for tenant 't2' with a logical name of 'c1' and label the result 'n2'
+    Then the returned container names 'n1' and 'n2' are different
+
+Scenario: Asking for the same name twice
+    Given a tenant labelled 't1'
+    When I get a blob container for tenant 't1' with a logical name of 'c1' and label the result 'n1'
+    And I get a blob container for tenant 't1' with a logical name of 'c1' and label the result 'n2'
+    Then the returned container names 'n1' and 'n2' are the same
+
+# This tests against known-good behaviour for how Marain.Tenancy stores tenant data - we are checking
+# the names of the containers that hold children for the root, 'Service Tenants' and 'Client Tenants'
+# tenants.
+Scenario Outline: Well known names
+    Given a tenant labelled 't1' with id '<tenantId>'
+    When I get a blob container for tenant 't1' with a logical name of '<logicalName>' and label the result 'n1'
+    Then the name returned container name 'n1' should be '<physicalName>'
+
+    Examples:
+    | tenantId                         | logicalName   | physicalName                             |
+    | f26450ab1668784bb327951c8b08f347 | corvustenancy | cce7b3deef3998aad88f5f0116f922a94e7cb6c4 |
+    | 3633754ac4c9be44b55bfe791b1780f1 | corvustenancy | 513162c27e77e52411ececa40f1e615455b01fc5 |
+    | 75b9261673c2714681f14c97bc0439fb | corvustenancy | 8f33344016814e24b39748c7d33e9da6f7772875 |

--- a/Solutions/Corvus.Tenancy.Specs/packages.lock.json
+++ b/Solutions/Corvus.Tenancy.Specs/packages.lock.json
@@ -4,14 +4,14 @@
     "net6.0": {
       "Corvus.Testing.SpecFlow.NUnit": {
         "type": "Direct",
-        "requested": "[1.4.6, )",
-        "resolved": "1.4.6",
-        "contentHash": "N7Vti+2pxUOFphEAh20JAN/ro8h02+TzLRnZaHoI5fEQysw6DPmCHklzWdMADxTTLSwLQ5DsrhZVKTSd7+LHBw==",
+        "requested": "[1.4.7, )",
+        "resolved": "1.4.7",
+        "contentHash": "Vli4LM72bkDNPZQ06bNS6s47o/4UQd0DuussioE4SP/gyx1CIHfctP83imQKivNqeTdpXNIwV5XM/VPtZL6Hxw==",
         "dependencies": {
-          "Corvus.Testing.SpecFlow": "1.4.6",
-          "Microsoft.NET.Test.Sdk": "[16.10.0, 17.0.0)",
+          "Corvus.Testing.SpecFlow": "1.4.7",
+          "Microsoft.NET.Test.Sdk": "16.11.0",
           "Moq": "4.16.1",
-          "SpecFlow.NUnit.Runners": "3.9.22",
+          "SpecFlow.NUnit.Runners": "3.9.40",
           "coverlet.msbuild": "3.1.0"
         }
       },
@@ -35,30 +35,35 @@
       },
       "Microsoft.Extensions.Configuration.EnvironmentVariables": {
         "type": "Direct",
-        "requested": "[3.1.*, )",
-        "resolved": "3.1.22",
-        "contentHash": "XbLKqiXeaGtCHRTu3hkEWV8h3Q91QrDQSeBzEgR2FFc5/dss/2Cnk9Y/q6q+iilyuLH/x2AZuJ31ejwzqGwBuw==",
+        "requested": "[6.0.*, )",
+        "resolved": "6.0.0",
+        "contentHash": "DjYkzqvhiHCq38LW71PcIxXk6nhtV6VySP9yDcSO0goPl7YCU1VG1f2Wbgy58lkA10pWkjHCblZPUyboCB93ZA==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "3.1.22"
+          "Microsoft.Extensions.Configuration": "6.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "6.0.0"
         }
       },
       "Microsoft.Extensions.Configuration.Json": {
         "type": "Direct",
-        "requested": "[3.1.*, )",
-        "resolved": "3.1.22",
-        "contentHash": "KwiV7M3pqeFQmY07ZM7RZy9xR30bSxb7XVK/omWlxMGiMk493xF2b8Y12DM83sr4ZPmb1/I8EHXnY0o8PsoRKA==",
+        "requested": "[6.0.*, )",
+        "resolved": "6.0.0",
+        "contentHash": "GJGery6QytCzS/BxJ96klgG9in3uH26KcUBbiVG/coNDXCRq6LGVVlUT4vXq34KPuM+R2av+LeYdX9h4IZOCUg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "3.1.22",
-          "Microsoft.Extensions.Configuration.FileExtensions": "3.1.22"
+          "Microsoft.Extensions.Configuration": "6.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "6.0.0",
+          "Microsoft.Extensions.Configuration.FileExtensions": "6.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "6.0.0",
+          "System.Text.Json": "6.0.0"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
         "type": "Direct",
-        "requested": "[3.1.*, )",
-        "resolved": "3.1.22",
-        "contentHash": "QrzfKU8te2X0ykM8XY9YzLvzTGO8qOMq45/Y2sy5gZryQqYe9CxEr0ulwG0idpL+ByK7luX7djmtT8Nv1mMaZw==",
+        "requested": "[6.0.*, )",
+        "resolved": "6.0.0",
+        "contentHash": "k6PWQMuoBDGGHOQTtyois2u4AwyVcIwL2LaSLlTZQm2CYcJ1pxbt6jfAnpWmzENA/wfrYRI/X9DTLoUkE4AsLw==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.22"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
       },
       "Roslynator.Analyzers": {
@@ -205,17 +210,17 @@
       },
       "Corvus.Identity.Abstractions": {
         "type": "Transitive",
-        "resolved": "3.0.0-alpha.9",
-        "contentHash": "oELgTNY72gNDrHyErcBwek5hT01d98Q8BESEaOD+HYKd3poAA9L9fFuC8KGMuUlHFOOIZknZYV5Jg5EHcZiqFg=="
+        "resolved": "3.0.0",
+        "contentHash": "fGYhKMz/n1Ejv77r+0bmzdC9EW3sCfZ3P8dky6rrOEGK4Kijd9yjTwoFEaG9ZHPXu5C7r2O2VqpesgIDkn5iQA=="
       },
       "Corvus.Identity.Azure": {
         "type": "Transitive",
-        "resolved": "3.0.0-alpha.9",
-        "contentHash": "KpRo83ibqhJbtAK6zv4EpEcU7xtuhmHAUHNKBiRtnqy+/4y2DPDm1C9yKMqCNsg+H7EX27esASnADTuvCGY81A==",
+        "resolved": "3.0.0",
+        "contentHash": "TYNTb4CD0pyn9WX4gC8TFGTU0v4inAkVEEG9xCyASgpp0ahMlL8RUfgQAwKZqr6yJ+tHpdjlx02mHJeSWidSiA==",
         "dependencies": {
           "Azure.Identity": "1.5.0",
           "Azure.Security.KeyVault.Secrets": "4.2.0",
-          "Corvus.Identity.Abstractions": "3.0.0-alpha.9",
+          "Corvus.Identity.Abstractions": "3.0.0",
           "Microsoft.Extensions.Caching.Memory": "6.0.0",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0"
         }
@@ -232,41 +237,41 @@
       },
       "Corvus.Storage.Azure.BlobStorage": {
         "type": "Transitive",
-        "resolved": "0.1.0-preview.10",
-        "contentHash": "mwKNUcOEM9dJH0ildGwzM/19B3n5mBY5yiRvrKtS5HuRpzNaCgdgQcVrGQHK1Kl1vEecPt9cLp9Edsbn2BfYhQ==",
+        "resolved": "1.0.0",
+        "contentHash": "jskZtDcYc5DJySAMwKkbcMKW5zJvaVOZdRfCmRoruk8yJvGxgJ92MhsdXmUSBOgvq7zC0CkOS0bF18WAgt6Tnw==",
         "dependencies": {
           "Azure.Storage.Blobs": "12.10.0",
-          "Corvus.Storage.Common": "0.1.0-preview.10"
+          "Corvus.Storage.Common": "1.0.0"
         }
       },
       "Corvus.Storage.Azure.Cosmos": {
         "type": "Transitive",
-        "resolved": "0.1.0-preview.10",
-        "contentHash": "rBtbCYRNl41s/xre1Re1kQJa+ciZWTxQRljCVcU5ttQzKXBfjkTVE2i+H6/Zr8fY9BLkpf5RawHPmyESAscQfg==",
+        "resolved": "1.0.0",
+        "contentHash": "SjhO1w5JZgGUoWm2g39LpRwtbPWfyXanIjNThQHin06IKlnPtWs5YtCJ1THxbofNNSwim7hTEtoyURCGtlPxkQ==",
         "dependencies": {
-          "Corvus.Storage.Common": "0.1.0-preview.10",
+          "Corvus.Storage.Common": "1.0.0",
           "Microsoft.Azure.Cosmos": "3.23.0"
         }
       },
       "Corvus.Storage.Common": {
         "type": "Transitive",
-        "resolved": "0.1.0-preview.10",
-        "contentHash": "Z0w8SzNSw0xbgjPM/4y5iP+0CzSeBwd2YMc3f2Qt23yZE+08wMUAWYh9nfelzAkBE4RVZrRDeBhbajlaU5zcXw==",
+        "resolved": "1.0.0",
+        "contentHash": "JF5H73X+s9MvJODJZ69ajbLBqPOUpBLaPYkEUO5SIsSvu+suRoOrkqmDnc8EKUFOutdq5jC9PsfLBbV0v6eaNw==",
         "dependencies": {
-          "Corvus.Identity.Azure": "3.0.0-alpha.9",
+          "Corvus.Identity.Azure": "3.0.0",
           "Microsoft.Extensions.Configuration.Binder": "3.1.22"
         }
       },
       "Corvus.Testing.SpecFlow": {
         "type": "Transitive",
-        "resolved": "1.4.6",
-        "contentHash": "EmakRYEWtLqOXJXV8vOq4bOikivszKcclnRClM65IULefSCY1Cm+pP5wvJusetZWRQ7xXjvI9Hzp25T1MJmVBQ==",
+        "resolved": "1.4.7",
+        "contentHash": "qGqOQt/9x95MOmUyA57JgNmdWRF1lgKjYEjU9IXw3ElMYs5S93I0qHiqBdQCIDq8qHxkXgo6cnDIJsrBLCrReQ==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "3.1.20",
-          "Microsoft.Extensions.DependencyInjection": "3.1.20",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.20",
+          "Microsoft.Extensions.Configuration.Abstractions": "3.1.21",
+          "Microsoft.Extensions.DependencyInjection": "3.1.21",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.21",
           "NUnit": "3.13.2",
-          "SpecFlow": "3.9.22",
+          "SpecFlow": "3.9.40",
           "System.Management": "4.7.0"
         }
       },
@@ -275,26 +280,10 @@
         "resolved": "3.1.0",
         "contentHash": "xOv5HZagq0I6uF4vt8NVVpwcA2W/uGmNcbLStao2eMk98RQH5NFPQuouh2nWWPSZrNIhGG/iYbBn2pO4s5i+ig=="
       },
-      "Cucumber.Messages": {
-        "type": "Transitive",
-        "resolved": "6.0.1",
-        "contentHash": "R/2XAU6Zwdnlgga/YLYxwbKf4ai0JYyeX25l85t0nNgagR2aP8hnqrLtJjgswuXVa2WlQdjXUfJqUX8YTjzlXw==",
-        "dependencies": {
-          "Google.Protobuf": "3.7.0"
-        }
-      },
       "Gherkin": {
         "type": "Transitive",
         "resolved": "19.0.3",
         "contentHash": "kq9feqMojMj9aABrHb/ABEPaH2Y4dSclseSahAru6qxCeqVQNLLTgw/6vZMauzI1yBUL2fz03ub5yEd5btLfvg=="
-      },
-      "Google.Protobuf": {
-        "type": "Transitive",
-        "resolved": "3.7.0",
-        "contentHash": "OvssyqQTrpJgdH4fjztsCV9AhUo9jgGpDbZ5XAAqC+X6MIUsifHk8Woeom1HXlHdqo/XebiEMpYySE9AxybJ9g==",
-        "dependencies": {
-          "NETStandard.Library": "1.6.1"
-        }
       },
       "Gremlin.Net": {
         "type": "Transitive",
@@ -468,8 +457,8 @@
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
-        "resolved": "16.10.0",
-        "contentHash": "7g0UjAwhEi2OBBv8SDV3wZ6J103cQyZbKVgDy59fnNdlbv0XpUCfdBZiSW5yVK/d2jp6faCdGh7VnI/F2JZO+Q=="
+        "resolved": "16.11.0",
+        "contentHash": "wf6lpAeCqP0KFfbDVtfL50lr7jY1gq0+0oSphyksfLOEygMDXqnaxHK5LPFtMEhYSEtgXdNyXNnEddOqQQUdlQ=="
       },
       "Microsoft.CSharp": {
         "type": "Transitive",
@@ -546,10 +535,11 @@
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
-        "resolved": "3.1.22",
-        "contentHash": "pk9tfTk3NCFdKqdWIWeoGAy/wiqVk38hA9Gso3c3deRLWqu4/5Jipp0X+fzgAXlELTN9AIxkkhRePTDFjBpQfQ==",
+        "resolved": "6.0.0",
+        "contentHash": "tq2wXyh3fL17EMF2bXgRhU7JrbO3on93MRKYxzz4JzzvuGSA1l0W3GI9/tl8EO89TH+KWEymP7bcFway6z9fXg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "3.1.22"
+          "Microsoft.Extensions.Configuration.Abstractions": "6.0.0",
+          "Microsoft.Extensions.Primitives": "6.0.0"
         }
       },
       "Microsoft.Extensions.Configuration.Abstractions": {
@@ -570,11 +560,14 @@
       },
       "Microsoft.Extensions.Configuration.FileExtensions": {
         "type": "Transitive",
-        "resolved": "3.1.22",
-        "contentHash": "CW1sZ8io+k59fS6jD2pJ7zIcJK0NaDX9nXWTO77YxPJeV1dHuheeoG693j7olUt8ASFRcjYsvM7TJh6s6f2AWw==",
+        "resolved": "6.0.0",
+        "contentHash": "V4Dth2cYMZpw3HhGw9XUDIijpI6gN+22LDt0AhufIgOppCUfpWX4483OmN+dFXRJkJLc8Tv0Q8QK+1ingT2+KQ==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "3.1.22",
-          "Microsoft.Extensions.FileProviders.Physical": "3.1.22"
+          "Microsoft.Extensions.Configuration": "6.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "6.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "6.0.0",
+          "Microsoft.Extensions.FileProviders.Physical": "6.0.0",
+          "Microsoft.Extensions.Primitives": "6.0.0"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
@@ -596,25 +589,26 @@
       },
       "Microsoft.Extensions.FileProviders.Abstractions": {
         "type": "Transitive",
-        "resolved": "3.1.22",
-        "contentHash": "bb7fvafHZkCURAbDkDcizqqYfuRb7/wpwraEisxMxqHwMUMNUaGZGO7+PPa5FJCiycgzdlF3zbKbecZUufJU3g==",
+        "resolved": "6.0.0",
+        "contentHash": "0pd4/fho0gC12rQswaGQxbU34jOS1TPS8lZPpkFCH68ppQjHNHYle9iRuHeev1LhrJ94YPvzcRd8UmIuFk23Qw==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "3.1.22"
+          "Microsoft.Extensions.Primitives": "6.0.0"
         }
       },
       "Microsoft.Extensions.FileProviders.Physical": {
         "type": "Transitive",
-        "resolved": "3.1.22",
-        "contentHash": "BnUOyfJtH0JNfGg9ZcA8WK9qs2rjs4L8N9LAVTNLn+/T2PS7+ZtuOthlFQzvBKl4FIXPjEyLu6olORDklgkf/w==",
+        "resolved": "6.0.0",
+        "contentHash": "QvkL7l0nM8udt3gfyu0Vw8bbCXblxaKOl7c2oBfgGy4LCURRaL9XWZX1FWJrQc43oMokVneVxH38iz+bY1sbhg==",
         "dependencies": {
-          "Microsoft.Extensions.FileProviders.Abstractions": "3.1.22",
-          "Microsoft.Extensions.FileSystemGlobbing": "3.1.22"
+          "Microsoft.Extensions.FileProviders.Abstractions": "6.0.0",
+          "Microsoft.Extensions.FileSystemGlobbing": "6.0.0",
+          "Microsoft.Extensions.Primitives": "6.0.0"
         }
       },
       "Microsoft.Extensions.FileSystemGlobbing": {
         "type": "Transitive",
-        "resolved": "3.1.22",
-        "contentHash": "E29Ob/T46KcucsX7OD6fesYolLp95hKx7y1EtBlqWN82i8fUpJ8a6sgMD1OSEID+fnptjic2dzAlw9Ry9W2kFA=="
+        "resolved": "6.0.0",
+        "contentHash": "ip8jnL1aPiaPeKINCqaTEbvBFDmVx9dXQEBZ2HOBRXPD1eabGNqP/bKlsIcp7U2lGxiXd5xIhoFcmY8nM4Hdiw=="
       },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "Transitive",
@@ -686,11 +680,11 @@
       },
       "Microsoft.NET.Test.Sdk": {
         "type": "Transitive",
-        "resolved": "16.10.0",
-        "contentHash": "/9x6TV1SUi+rtKi8UYa7ml7SEWhb0A5FuyeF0nwwUKVjdk5WaWuLPjntHVWoDuYP25KBruoxWxs7WdhDMjWxXw==",
+        "resolved": "16.11.0",
+        "contentHash": "f4mbG1SUSkNWF5p7B3Y8ZxMsvKhxCmpZhdl+w6tMtLSUGE7Izi1syU6TkmKOvB2BV66pdbENConFAISOix4ohQ==",
         "dependencies": {
-          "Microsoft.CodeCoverage": "16.10.0",
-          "Microsoft.TestPlatform.TestHost": "16.10.0"
+          "Microsoft.CodeCoverage": "16.11.0",
+          "Microsoft.TestPlatform.TestHost": "16.11.0"
         }
       },
       "Microsoft.NETCore.Platforms": {
@@ -756,8 +750,8 @@
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
-        "resolved": "16.10.0",
-        "contentHash": "DYp9eKg3zffZuePhgdUrh5tHkt1YOaSraVH87r4WXDOjag1/n08aFl1vRhWP8y2RoBLTHdcZRTDOhQyYMxAYNg==",
+        "resolved": "16.11.0",
+        "contentHash": "EiknJx9N9Z30gs7R+HHhki7fA8EiiM3pwD1vkw3bFsBC8kdVq/O7mHf1hrg5aJp+ASO6BoOzQueD2ysfTOy/Bg==",
         "dependencies": {
           "NuGet.Frameworks": "5.0.0",
           "System.Reflection.Metadata": "1.6.0"
@@ -765,10 +759,10 @@
       },
       "Microsoft.TestPlatform.TestHost": {
         "type": "Transitive",
-        "resolved": "16.10.0",
-        "contentHash": "KAlB2QQRwznIH02WNl9eAuUP6/tn4IbAw4EXrvV1POTUjxuv4Dqg0u3Nn5lC9T3WIHupCHfsTcJMgsJYdi31Ig==",
+        "resolved": "16.11.0",
+        "contentHash": "/Q+R0EcCJE8JaYCk+bGReicw/xrB0HhecrYrUcLbn95BnAlaTJrZhoLkUhvtKTAVtqX/AIKWXYtutiU/Q6QUgg==",
         "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "16.10.0",
+          "Microsoft.TestPlatform.ObjectModel": "16.11.0",
           "Newtonsoft.Json": "9.0.1"
         }
       },
@@ -1032,11 +1026,10 @@
       },
       "SpecFlow": {
         "type": "Transitive",
-        "resolved": "3.9.22",
-        "contentHash": "A3wZUoJaJjkll/Qvun8SJo7W869kO+1hm/FNkidNdnfbmOJA4Q8f0J80pr5wqIkKaYMQTRVvt18Y6HisgEZbUw==",
+        "resolved": "3.9.40",
+        "contentHash": "ru7twstJSKrTv3XfcxyttzrdZ/FvXOF5cYN/x/2js755wVk1zpSPUPa/ml3lSZmPNkS5OAOuSt1JLEa5hhDhdw==",
         "dependencies": {
           "BoDi": "1.5.0",
-          "Cucumber.Messages": "[6.0.1, 7.0.0)",
           "Gherkin": "19.0.3",
           "Microsoft.Extensions.DependencyModel": "1.0.3",
           "SpecFlow.Internal.Json": "1.0.8",
@@ -1052,30 +1045,30 @@
       },
       "SpecFlow.NUnit": {
         "type": "Transitive",
-        "resolved": "3.9.22",
-        "contentHash": "o0d1zHMf9NcXLxXhG2NllWDnJCItKtDbpKyL5Kltf9AUYam7opvm3uFYG03WePnoPU9qgD+KLOM9IjNDZ4quaw==",
+        "resolved": "3.9.40",
+        "contentHash": "+brbJAe0LLzmXh2L78kOJc2fa5EH/7cugmbnfZQdBeWCzL6iFDWFl3MHZ0xx/2BQyu6N/xokqw53Rl30LIo7lw==",
         "dependencies": {
           "NUnit": "3.13.1",
-          "SpecFlow": "[3.9.22]",
-          "SpecFlow.Tools.MsBuild.Generation": "[3.9.22]"
+          "SpecFlow": "[3.9.40]",
+          "SpecFlow.Tools.MsBuild.Generation": "[3.9.40]"
         }
       },
       "SpecFlow.NUnit.Runners": {
         "type": "Transitive",
-        "resolved": "3.9.22",
-        "contentHash": "cVQ49DWTyEqDYhiZjZSItkH0ALEVUBWvh7BOK5DCMzzsooid0EqNXWyrlzHk8OkzOmMDHs5JRmwqwe0biHZ5AA==",
+        "resolved": "3.9.40",
+        "contentHash": "vScntUGHtokExBWweUG9XOkjTum1B14lP4KU9T2rNW+gIGJBG99YmnR3/NMy4YMfASg5VkGJLx4icpZDYJENsQ==",
         "dependencies": {
           "NUnit.Console": "3.12.0",
           "NUnit3TestAdapter": "3.17.0",
-          "SpecFlow.NUnit": "[3.9.22]"
+          "SpecFlow.NUnit": "[3.9.40]"
         }
       },
       "SpecFlow.Tools.MsBuild.Generation": {
         "type": "Transitive",
-        "resolved": "3.9.22",
-        "contentHash": "JrX8QY9mN+X5RUsjS2GY6l+eOAZ6S/sWiS6yi2+RxyyrvPmskQH7TYCm69dcNDefncXg/wZk3g/SE3VtjfdcVg==",
+        "resolved": "3.9.40",
+        "contentHash": "DFClKzQH0ijUBiZNpas8sQ66EdGwVSS18UtC1hVIM7PiT0F+xzKs4VX5hsz+ZY/RKyQEfY9HELUAC8AoZicxSg==",
         "dependencies": {
-          "SpecFlow": "[3.9.22]"
+          "SpecFlow": "[3.9.40]"
         }
       },
       "System.AppContext": {
@@ -2161,13 +2154,20 @@
       },
       "System.Text.Encodings.Web": {
         "type": "Transitive",
-        "resolved": "4.7.2",
-        "contentHash": "iTUgB/WtrZ1sWZs84F2hwyQhiRH6QNjQv2DkwrH+WP6RoFga2Q1m3f9/Q7FG8cck8AdHitQkmkXSY8qylcDmuA=="
+        "resolved": "6.0.0",
+        "contentHash": "Vg8eB5Tawm1IFqj4TVK1czJX89rhFxJo9ELqc/Eiq0eXy13RK00eubyU6TJE6y+GQXjyV5gSfiewDUZjQgSE0w==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
       },
       "System.Text.Json": {
         "type": "Transitive",
-        "resolved": "4.6.0",
-        "contentHash": "4F8Xe+JIkVoDJ8hDAZ7HqLkjctN/6WItJIzQaifBwClC7wmoLSda/Sv2i6i1kycqDb3hWF4JCVbpAweyOKHEUA=="
+        "resolved": "6.0.0",
+        "contentHash": "zaJsHfESQvJ11vbXnNlkrR46IaMULk/gHxYsJphzSF+07kTjPHv+Oc14w6QEOfo3Q4hqLJgStUaYB9DBl0TmWg==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
+          "System.Text.Encodings.Web": "6.0.0"
+        }
       },
       "System.Text.RegularExpressions": {
         "type": "Transitive",
@@ -2403,14 +2403,14 @@
       "corvus.storage.azure.blobstorage.tenancy": {
         "type": "Project",
         "dependencies": {
-          "Corvus.Storage.Azure.BlobStorage": "0.1.0-preview.10",
+          "Corvus.Storage.Azure.BlobStorage": "1.0.0",
           "Corvus.Tenancy.Abstractions": "1.0.0"
         }
       },
       "corvus.storage.azure.cosmos.tenancy": {
         "type": "Project",
         "dependencies": {
-          "Corvus.Storage.Azure.Cosmos": "0.1.0-preview.10",
+          "Corvus.Storage.Azure.Cosmos": "1.0.0",
           "Corvus.Tenancy.Abstractions": "1.0.0"
         }
       },


### PR DESCRIPTION
This provides a public way to form tenanted container names in a standard way, and also the means to convert those into hashed names for use in Azure Blob Storage. The hashing part is now implemented on top of the container name hashing in Corvus.Storage.

Also took this opportunity to make ITenant.ETag read-only. the fact that it was writable was an oversight, and we're about to release v3.0.0, so this is a good time to fix that. (Tenant.ETag remains writable, and that's the one that needs to be.)