### PR TITLE
Add tenanted name overrides that accept tenantId string

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -20,5 +20,5 @@ branches:
     - feature
     - support
     - hotfix
-next-version: "3.2"
+next-version: "3.3"
 

--- a/Solutions/Corvus.Storage.Azure.BlobStorage.Tenancy/Corvus/Storage/Azure/BlobStorage/Tenancy/AzureStorageBlobTenantedContainerNaming.cs
+++ b/Solutions/Corvus.Storage.Azure.BlobStorage.Tenancy/Corvus/Storage/Azure/BlobStorage/Tenancy/AzureStorageBlobTenantedContainerNaming.cs
@@ -28,8 +28,18 @@ namespace Corvus.Storage.Azure.BlobStorage.Tenancy
         /// <param name="containerName">The plain text name for the blob container.</param>
         /// <returns>The encoded name.</returns>
         public static string GetHashedTenantedBlobContainerNameFor(ITenant tenant, string containerName)
+            => GetHashedTenantedBlobContainerNameFor(tenant.Id, containerName);
+
+        /// <summary>
+        /// Make a container name safe to use as an Azure storage blob container name, and which
+        /// is unique for this combination of tenant and logical container name.
+        /// </summary>
+        /// <param name="tenantId">The id of the tenant for which to generate a name.</param>
+        /// <param name="containerName">The plain text name for the blob container.</param>
+        /// <returns>The encoded name.</returns>
+        public static string GetHashedTenantedBlobContainerNameFor(string tenantId, string containerName)
         {
-            string tenantedUnhashedContainerName = GetTenantedLogicalBlobContainerNameFor(tenant, containerName);
+            string tenantedUnhashedContainerName = GetTenantedLogicalBlobContainerNameFor(tenantId, containerName);
             return AzureStorageBlobContainerNaming.HashAndEncodeBlobContainerName(tenantedUnhashedContainerName);
         }
 
@@ -40,6 +50,15 @@ namespace Corvus.Storage.Azure.BlobStorage.Tenancy
         /// <param name="containerName">The plain text name for the blob container.</param>
         /// <returns>The encoded name.</returns>
         public static string GetTenantedLogicalBlobContainerNameFor(ITenant tenant, string containerName)
-            => $"{tenant.Id.ToLowerInvariant()}-{containerName}";
+            => GetTenantedLogicalBlobContainerNameFor(tenant.Id, containerName);
+
+        /// <summary>
+        /// Create a tenant-specific logical name for an Azure storage blob container name.
+        /// </summary>
+        /// <param name="tenantId">The id of the tenant for which to generate a name.</param>
+        /// <param name="containerName">The plain text name for the blob container.</param>
+        /// <returns>The encoded name.</returns>
+        public static string GetTenantedLogicalBlobContainerNameFor(string tenantId, string containerName)
+            => $"{tenantId.ToLowerInvariant()}-{containerName}";
     }
 }

--- a/Solutions/Corvus.Storage.Azure.BlobStorage.Tenancy/Corvus/Storage/Azure/BlobStorage/Tenancy/Internal/BlobContainerSourceWithTenantLegacyTransition.cs
+++ b/Solutions/Corvus.Storage.Azure.BlobStorage.Tenancy/Corvus/Storage/Azure/BlobStorage/Tenancy/Internal/BlobContainerSourceWithTenantLegacyTransition.cs
@@ -198,7 +198,7 @@ namespace Corvus.Storage.Azure.BlobStorage.Tenancy.Internal
                 {
                     Container = AzureStorageBlobTenantedContainerNaming.GetHashedTenantedBlobContainerNameFor(
                     tenant,
-                    containerName ?? throw new InvalidOperationException($"When the configuration does not specify a Container, you must supply a non-null logical container name")),
+                    containerName ?? throw new InvalidOperationException("When the configuration does not specify a Container, you must supply a non-null logical container name")),
                 }
                 : configuration;
         }

--- a/Solutions/Corvus.Storage.Azure.Cosmos.Tenancy/Corvus/Storage/Azure/Cosmos/Tenancy/CosmosTenantedContainerNaming.cs
+++ b/Solutions/Corvus.Storage.Azure.Cosmos.Tenancy/Corvus/Storage/Azure/Cosmos/Tenancy/CosmosTenantedContainerNaming.cs
@@ -19,7 +19,17 @@ public static class CosmosTenantedContainerNaming
     /// <param name="databaseName">The plain text name for the Cosmos database.</param>
     /// <returns>The encoded name.</returns>
     public static string GetTenantSpecificDatabaseNameFor(ITenant tenant, string databaseName)
-        => $"{tenant.Id.ToLowerInvariant()}-{databaseName}";
+        => GetTenantSpecificDatabaseNameFor(tenant.Id, databaseName);
+
+    /// <summary>
+    /// Make a Cosmos database name that is unique for this combination of tenant and logical
+    /// container name.
+    /// </summary>
+    /// <param name="tenantId">The id of the tenant for which to generate a name.</param>
+    /// <param name="databaseName">The plain text name for the Cosmos database.</param>
+    /// <returns>The encoded name.</returns>
+    public static string GetTenantSpecificDatabaseNameFor(string tenantId, string databaseName)
+        => $"{tenantId.ToLowerInvariant()}-{databaseName}";
 
     /// <summary>
     /// Make a container name that is unique for this combination of tenant and logical container
@@ -29,5 +39,15 @@ public static class CosmosTenantedContainerNaming
     /// <param name="containerName">The plain text name for the Cosmos container.</param>
     /// <returns>The encoded name.</returns>
     public static string GetTenantSpecificContainerNameFor(ITenant tenant, string containerName)
-        => $"{tenant.Id.ToLowerInvariant()}-{containerName}";
+        => GetTenantSpecificContainerNameFor(tenant.Id, containerName);
+
+    /// <summary>
+    /// Make a container name that is unique for this combination of tenant and logical container
+    /// name.
+    /// </summary>
+    /// <param name="tenantId">The id of the tenant for which to generate a name.</param>
+    /// <param name="containerName">The plain text name for the Cosmos container.</param>
+    /// <returns>The encoded name.</returns>
+    public static string GetTenantSpecificContainerNameFor(string tenantId, string containerName)
+        => $"{tenantId.ToLowerInvariant()}-{containerName}";
 }

--- a/Solutions/Corvus.Storage.Azure.TableStorage.Tenancy/Corvus/Storage/Azure/TableStorage/Tenancy/AzureTablesTenantedNaming.cs
+++ b/Solutions/Corvus.Storage.Azure.TableStorage.Tenancy/Corvus/Storage/Azure/TableStorage/Tenancy/AzureTablesTenantedNaming.cs
@@ -36,8 +36,18 @@ public static class AzureTablesTenantedNaming
     /// <param name="tableName">The plain text name for the table.</param>
     /// <returns>The encoded name.</returns>
     public static string GetHashedTenantedTableNameFor(ITenant tenant, string tableName)
+        => GetHashedTenantedTableNameFor(tenant.Id, tableName);
+
+    /// <summary>
+    /// Make a container name safe to use as an Azure Storage table name, and which is unique for
+    /// this combination of tenant and logical container name.
+    /// </summary>
+    /// <param name="tenantId">The id of the tenant for which to generate a name.</param>
+    /// <param name="tableName">The plain text name for the table.</param>
+    /// <returns>The encoded name.</returns>
+    public static string GetHashedTenantedTableNameFor(string tenantId, string tableName)
     {
-        string tenantedUnhashedContainerName = GetTenantedLogicalTableNameFor(tenant, tableName);
+        string tenantedUnhashedContainerName = GetTenantedLogicalTableNameFor(tenantId, tableName);
         return AzureTableNaming.HashAndEncodeTableName(tenantedUnhashedContainerName);
     }
 
@@ -48,5 +58,14 @@ public static class AzureTablesTenantedNaming
     /// <param name="tableName">The plain text name for the table.</param>
     /// <returns>The encoded name.</returns>
     public static string GetTenantedLogicalTableNameFor(ITenant tenant, string tableName)
-        => $"{tenant.Id.ToLowerInvariant()}-{tableName}";
+        => GetTenantedLogicalTableNameFor(tenant.Id, tableName);
+
+    /// <summary>
+    /// Create a tenant-specific logical name for an Azure storage blob container name.
+    /// </summary>
+    /// <param name="tenantId">The id of the tenant for which to generate a name.</param>
+    /// <param name="tableName">The plain text name for the table.</param>
+    /// <returns>The encoded name.</returns>
+    public static string GetTenantedLogicalTableNameFor(string tenantId, string tableName)
+        => $"{tenantId.ToLowerInvariant()}-{tableName}";
 }

--- a/Solutions/Corvus.Tenancy.Specs/Features/BlobStorage/BlobContainerNaming.feature
+++ b/Solutions/Corvus.Tenancy.Specs/Features/BlobStorage/BlobContainerNaming.feature
@@ -3,31 +3,56 @@
     In order to separate tenant data even when multiple tenants are sharing an Azure Storage Account
     I need to be able to generate tenanted names that meet Azure Storage's container constraints, and which are unique
 
-Scenario: Same tenant different logical names
+Scenario: Same tenant different logical names via ITenant
     Given a tenant labelled 't1'
     When I get a blob container name for tenant 't1' with a logical name of 'c1' and label the result 'n1'
     And I get a blob container name for tenant 't1' with a logical name of 'c2' and label the result 'n2'
     Then the returned container names 'n1' and 'n2' are different
 
-Scenario: Same logical name different tenants
+Scenario: Same tenant different logical names via tenantId
+    When I get a blob container name for tenantId 'f26450ab1668784bb327951c8b08f347' with a logical name of 'c1' and label the result 'n1'
+    And I get a blob container name for tenantId 'f26450ab1668784bb327951c8b08f347' with a logical name of 'c2' and label the result 'n2'
+    Then the returned container names 'n1' and 'n2' are different
+
+Scenario: Same logical name different tenants via ITenant
     Given a tenant labelled 't1'
     And a tenant labelled 't2'
     When I get a blob container name for tenant 't1' with a logical name of 'c1' and label the result 'n1'
     And I get a blob container name for tenant 't2' with a logical name of 'c1' and label the result 'n2'
     Then the returned container names 'n1' and 'n2' are different
 
-Scenario: Asking for the same name twice
+Scenario: Same logical name different tenants via tenantId
+    When I get a blob container name for tenantId 'f26450ab1668784bb327951c8b08f347' with a logical name of 'c1' and label the result 'n1'
+    And I get a blob container name for tenantId '3633754ac4c9be44b55bfe791b1780f1' with a logical name of 'c1' and label the result 'n2'
+    Then the returned container names 'n1' and 'n2' are different
+
+Scenario: Asking for the same name twice via ITenant
     Given a tenant labelled 't1'
     When I get a blob container name for tenant 't1' with a logical name of 'c1' and label the result 'n1'
     And I get a blob container name for tenant 't1' with a logical name of 'c1' and label the result 'n2'
     Then the returned container names 'n1' and 'n2' are the same
 
+Scenario: Asking for the same name twice via tenantId
+    When I get a blob container name for tenantId 'f26450ab1668784bb327951c8b08f347' with a logical name of 'c1' and label the result 'n1'
+    And I get a blob container name for tenantId 'f26450ab1668784bb327951c8b08f347' with a logical name of 'c1' and label the result 'n2'
+    Then the returned container names 'n1' and 'n2' are the same
+
 # This tests against known-good behaviour for how Marain.Tenancy stores tenant data - we are checking
 # the names of the containers that hold children for the root, 'Service Tenants' and 'Client Tenants'
 # tenants.
-Scenario Outline: Well known names
+Scenario Outline: Well known names via ITenant
     Given a tenant labelled 't1' with id '<tenantId>'
     When I get a blob container name for tenant 't1' with a logical name of '<logicalName>' and label the result 'n1'
+    Then the name returned container name 'n1' should be '<physicalName>'
+
+    Examples:
+    | tenantId                         | logicalName   | physicalName                             |
+    | f26450ab1668784bb327951c8b08f347 | corvustenancy | cce7b3deef3998aad88f5f0116f922a94e7cb6c4 |
+    | 3633754ac4c9be44b55bfe791b1780f1 | corvustenancy | 513162c27e77e52411ececa40f1e615455b01fc5 |
+    | 75b9261673c2714681f14c97bc0439fb | corvustenancy | 8f33344016814e24b39748c7d33e9da6f7772875 |
+
+Scenario Outline: Well known names via tenantId
+    When I get a blob container name for tenantId '<tenantId>' with a logical name of '<logicalName>' and label the result 'n1'
     Then the name returned container name 'n1' should be '<physicalName>'
 
     Examples:

--- a/Solutions/Corvus.Tenancy.Specs/Features/BlobStorage/BlobContainerNamingStepDefinitions.cs
+++ b/Solutions/Corvus.Tenancy.Specs/Features/BlobStorage/BlobContainerNamingStepDefinitions.cs
@@ -29,5 +29,14 @@ namespace Corvus.Tenancy.Specs.Features.BlobStorage
                 resultLabel,
                 AzureStorageBlobTenantedContainerNaming.GetHashedTenantedBlobContainerNameFor(tenant, logicalContainerName));
         }
+
+        [When("I get a blob container name for tenantId '([^']*)' with a logical name of '([^']*)' and label the result '([^']*)'")]
+        public void WhenIGetABlobContainerNameForTenantIdWithALogicalNameOfAndLabelTheResult(
+            string tenantId, string logicalContainerName, string resultLabel)
+        {
+            this.tenantedNameBindings.AddTenantedContainerName(
+                resultLabel,
+                AzureStorageBlobTenantedContainerNaming.GetHashedTenantedBlobContainerNameFor(tenantId, logicalContainerName));
+        }
     }
 }

--- a/Solutions/Corvus.Tenancy.Specs/Features/Cosmos/CosmosTenantSpecificNames.feature
+++ b/Solutions/Corvus.Tenancy.Specs/Features/Cosmos/CosmosTenantSpecificNames.feature
@@ -3,40 +3,71 @@
     In order to separate tenant data even when multiple tenants are sharing an Azure Storage Account
     I need to be able to generate tenanted names that meet Azure Storage's container constraints, and which are unique
 
-Scenario: Same tenant different logical database names
+Scenario: Same tenant different logical database names via ITenant
     Given a tenant labelled 't1'
     When I get a Cosmos database name for tenant 't1' with a logical name of 'c1' and label the result 'n1'
     And I get a Cosmos database name for tenant 't1' with a logical name of 'c2' and label the result 'n2'
     Then the returned container names 'n1' and 'n2' are different
 
-Scenario: Same tenant different logical container names
+Scenario: Same tenant different logical database names via tenantId
+    When I get a Cosmos database name for tenantId 'f26450ab1668784bb327951c8b08f347' with a logical name of 'c1' and label the result 'n1'
+    And I get a Cosmos database name for tenantId 'f26450ab1668784bb327951c8b08f347' with a logical name of 'c2' and label the result 'n2'
+    Then the returned container names 'n1' and 'n2' are different
+
+Scenario: Same tenant different logical container names via ITenant
     Given a tenant labelled 't1'
     When I get a Cosmos container name for tenant 't1' with a logical name of 'c1' and label the result 'n1'
     And I get a Cosmos container name for tenant 't1' with a logical name of 'c2' and label the result 'n2'
     Then the returned container names 'n1' and 'n2' are different
 
-Scenario: Same logical database name different tenants
+Scenario: Same tenant different logical container names via tenantId
+    When I get a Cosmos container name for tenantId 'f26450ab1668784bb327951c8b08f347' with a logical name of 'c1' and label the result 'n1'
+    And I get a Cosmos container name for tenantId 'f26450ab1668784bb327951c8b08f347' with a logical name of 'c2' and label the result 'n2'
+    Then the returned container names 'n1' and 'n2' are different
+
+Scenario: Same logical database name different tenants via ITenant
     Given a tenant labelled 't1'
     And a tenant labelled 't2'
     When I get a Cosmos database name for tenant 't1' with a logical name of 'c1' and label the result 'n1'
     And I get a Cosmos database name for tenant 't2' with a logical name of 'c1' and label the result 'n2'
     Then the returned container names 'n1' and 'n2' are different
 
-Scenario: Same logical container name different tenants
+Scenario: Same logical database name different tenants via tenantId
+    When I get a Cosmos database name for tenantId 'f26450ab1668784bb327951c8b08f347' with a logical name of 'c1' and label the result 'n1'
+    And I get a Cosmos database name for tenantId '3633754ac4c9be44b55bfe791b1780f1' with a logical name of 'c1' and label the result 'n2'
+    Then the returned container names 'n1' and 'n2' are different
+
+Scenario: Same logical container name different tenants via ITenant
     Given a tenant labelled 't1'
     And a tenant labelled 't2'
     When I get a Cosmos container name for tenant 't1' with a logical name of 'c1' and label the result 'n1'
     And I get a Cosmos container name for tenant 't2' with a logical name of 'c1' and label the result 'n2'
     Then the returned container names 'n1' and 'n2' are different
 
-Scenario: Asking for the same database name twice
+Scenario: Same logical container name different tenants via tenantId
+    When I get a Cosmos container name for tenantId 'f26450ab1668784bb327951c8b08f347' with a logical name of 'c1' and label the result 'n1'
+    And I get a Cosmos container name for tenantId '3633754ac4c9be44b55bfe791b1780f1' with a logical name of 'c1' and label the result 'n2'
+    Then the returned container names 'n1' and 'n2' are different
+
+Scenario: Asking for the same database name twice via ITenant
     Given a tenant labelled 't1'
     When I get a Cosmos database name for tenant 't1' with a logical name of 'c1' and label the result 'n1'
     And I get a Cosmos database name for tenant 't1' with a logical name of 'c1' and label the result 'n2'
     Then the returned container names 'n1' and 'n2' are the same
 
-Scenario: Asking for the same container name twice
+Scenario: Asking for the same database name twice via tenantId
+    When I get a Cosmos database name for tenantId 'f26450ab1668784bb327951c8b08f347' with a logical name of 'c1' and label the result 'n1'
+    And I get a Cosmos database name for tenantId 'f26450ab1668784bb327951c8b08f347' with a logical name of 'c1' and label the result 'n2'
+    Then the returned container names 'n1' and 'n2' are the same
+
+Scenario: Asking for the same container name twice via ITenant
     Given a tenant labelled 't1'
     When I get a Cosmos container name for tenant 't1' with a logical name of 'c1' and label the result 'n1'
     And I get a Cosmos container name for tenant 't1' with a logical name of 'c1' and label the result 'n2'
+    Then the returned container names 'n1' and 'n2' are the same
+
+Scenario: Asking for the same container name twice via tenantId
+    Given a tenant labelled 't1'
+    When I get a Cosmos container name for tenantId 'f26450ab1668784bb327951c8b08f347' with a logical name of 'c1' and label the result 'n1'
+    And I get a Cosmos container name for tenantId 'f26450ab1668784bb327951c8b08f347' with a logical name of 'c1' and label the result 'n2'
     Then the returned container names 'n1' and 'n2' are the same

--- a/Solutions/Corvus.Tenancy.Specs/Features/Cosmos/CosmosTenantSpecificNamesStepDefinitions.cs
+++ b/Solutions/Corvus.Tenancy.Specs/Features/Cosmos/CosmosTenantSpecificNamesStepDefinitions.cs
@@ -30,6 +30,15 @@ public class CosmosTenantSpecificNamesStepDefinitions
             CosmosTenantedContainerNaming.GetTenantSpecificDatabaseNameFor(tenant, logicalDatabaseName));
     }
 
+    [When("I get a Cosmos database name for tenantId '([^']*)' with a logical name of '([^']*)' and label the result '([^']*)'")]
+    public void WhenIGetACosmosDatabaseNameForTenantIdWithALogicalNameOfAndLabelTheResult(
+        string tenantId, string logicalDatabaseName, string resultLabel)
+    {
+        this.tenantedNameBindings.AddTenantedContainerName(
+            resultLabel,
+            CosmosTenantedContainerNaming.GetTenantSpecificDatabaseNameFor(tenantId, logicalDatabaseName));
+    }
+
     [When("I get a Cosmos container name for tenant '([^']*)' with a logical name of '([^']*)' and label the result '([^']*)'")]
     public void WhenIGetACosmosContainerNameForTenantWithALogicalNameOfAndLabelTheResult(
         string tenantLabel, string logicalContainerName, string resultLabel)
@@ -38,5 +47,14 @@ public class CosmosTenantSpecificNamesStepDefinitions
         this.tenantedNameBindings.AddTenantedContainerName(
             resultLabel,
             CosmosTenantedContainerNaming.GetTenantSpecificContainerNameFor(tenant, logicalContainerName));
+    }
+
+    [When("I get a Cosmos container name for tenantId '([^']*)' with a logical name of '([^']*)' and label the result '([^']*)'")]
+    public void WhenIGetACosmosContainerNameForTenantIdWithALogicalNameOfAndLabelTheResult(
+        string tenantId, string logicalContainerName, string resultLabel)
+    {
+        this.tenantedNameBindings.AddTenantedContainerName(
+            resultLabel,
+            CosmosTenantedContainerNaming.GetTenantSpecificContainerNameFor(tenantId, logicalContainerName));
     }
 }

--- a/Solutions/Corvus.Tenancy.Specs/Features/TableStorage/TableNaming.feature
+++ b/Solutions/Corvus.Tenancy.Specs/Features/TableStorage/TableNaming.feature
@@ -3,21 +3,36 @@
     In order to separate tenant data even when multiple tenants are sharing an Azure Storage account or Cosmos DB account
     I need to be able to generate tenanted names that meet Azure Storage's container constraints, and which are unique
 
-Scenario: Same tenant different logical names
+Scenario: Same tenant different logical names via ITenant
     Given a tenant labelled 't1'
     When I get an Azure table name for tenant 't1' with a logical name of 'c1' and label the result 'n1'
     And I get an Azure table name for tenant 't1' with a logical name of 'c2' and label the result 'n2'
     Then the returned container names 'n1' and 'n2' are different
 
-Scenario: Same logical name different tenants
+Scenario: Same tenant different logical names via tenantId
+    When I get an Azure table name for tenantId 'f26450ab1668784bb327951c8b08f347' with a logical name of 'c1' and label the result 'n1'
+    And I get an Azure table name for tenantId 'f26450ab1668784bb327951c8b08f347' with a logical name of 'c2' and label the result 'n2'
+    Then the returned container names 'n1' and 'n2' are different
+
+Scenario: Same logical name different tenants via ITenant
     Given a tenant labelled 't1'
     And a tenant labelled 't2'
     When I get an Azure table name for tenant 't1' with a logical name of 'c1' and label the result 'n1'
     And I get an Azure table name for tenant 't2' with a logical name of 'c1' and label the result 'n2'
     Then the returned container names 'n1' and 'n2' are different
 
-Scenario: Asking for the same name twice
+Scenario: Same logical name different tenants via tenantId
+    When I get an Azure table name for tenantId 'f26450ab1668784bb327951c8b08f347' with a logical name of 'c1' and label the result 'n1'
+    And I get an Azure table name for tenantId '3633754ac4c9be44b55bfe791b1780f1' with a logical name of 'c1' and label the result 'n2'
+    Then the returned container names 'n1' and 'n2' are different
+
+Scenario: Asking for the same name twice via ITenant
     Given a tenant labelled 't1'
     When I get an Azure table name for tenant 't1' with a logical name of 'c1' and label the result 'n1'
     And I get an Azure table name for tenant 't1' with a logical name of 'c1' and label the result 'n2'
+    Then the returned container names 'n1' and 'n2' are the same
+
+Scenario: Asking for the same name twice via tenantId
+    When I get an Azure table name for tenantId 'f26450ab1668784bb327951c8b08f347' with a logical name of 'c1' and label the result 'n1'
+    And I get an Azure table name for tenantId 'f26450ab1668784bb327951c8b08f347' with a logical name of 'c1' and label the result 'n2'
     Then the returned container names 'n1' and 'n2' are the same

--- a/Solutions/Corvus.Tenancy.Specs/Features/TableStorage/TableNamingStepDefinitions.cs
+++ b/Solutions/Corvus.Tenancy.Specs/Features/TableStorage/TableNamingStepDefinitions.cs
@@ -29,4 +29,13 @@ public sealed class TableNamingStepDefinitions
             resultLabel,
             AzureTablesTenantedNaming.GetHashedTenantedTableNameFor(tenant, logicalTableName));
     }
+
+    [When("I get an Azure table name for tenantId '([^']*)' with a logical name of '([^']*)' and label the result '([^']*)'")]
+    public void WhenIGetAnAzureTableNameForTenantIdWithALogicalNameOfAndLabelTheResult(
+        string tenantId, string logicalTableName, string resultLabel)
+    {
+        this.tenantedNameBindings.AddTenantedContainerName(
+            resultLabel,
+            AzureTablesTenantedNaming.GetHashedTenantedTableNameFor(tenantId, logicalTableName));
+    }
 }

--- a/Solutions/Corvus.Tenancy.Specs/packages.lock.json
+++ b/Solutions/Corvus.Tenancy.Specs/packages.lock.json
@@ -17,11 +17,11 @@
       },
       "Endjin.RecommendedPractices.GitHub": {
         "type": "Direct",
-        "requested": "[2.1.1, )",
-        "resolved": "2.1.1",
-        "contentHash": "f+fDu+C3yh+fuPrlm3ZOytILw/nl1IYjLSjs8cjf37K8IU45elqsbFM3Q7lkNsUz8v4tG3Ags+WPS7t2c8zH1w==",
+        "requested": "[2.1.2, )",
+        "resolved": "2.1.2",
+        "contentHash": "mBUCmeSdWWrIQKuuYd9zflcwupRDmpF39dsbb07e6azlNIQqaE1J5TQa17c3SFVRXn9IZrClsmKoMporRTAWwQ==",
         "dependencies": {
-          "Endjin.RecommendedPractices": "2.1.1",
+          "Endjin.RecommendedPractices": "2.1.2",
           "Microsoft.SourceLink.GitHub": "1.1.1"
         }
       },
@@ -69,17 +69,17 @@
       },
       "Roslynator.Analyzers": {
         "type": "Direct",
-        "requested": "[4.1.0, )",
-        "resolved": "4.1.0",
-        "contentHash": "xTSs7KdwhIUOTqEubcfW043o0dpSjKpNF+C6Aj5OuJv69rVJ0ypjChNeeXRALB2I1S9W1+qmgbVWYg7qftgoCA=="
+        "requested": "[4.1.1, )",
+        "resolved": "4.1.1",
+        "contentHash": "3cPVlrB1PytlO1ztZZBOExDKQWpMZgI15ZDa0BqLu0l6xv+xIRfEpqjNRcpvUy3aLxWTkPgSKZbbaO+VoFEJ1g=="
       },
       "StyleCop.Analyzers": {
         "type": "Direct",
-        "requested": "[1.2.0-beta.406, )",
-        "resolved": "1.2.0-beta.406",
-        "contentHash": "YbsYoczQPZyz+4nmQ7bBiU9uQkk7Q2KUizQWEv01S4/ImCdJFiHvJfm8HAINNS0cvSLOA7xM9Y+KWQ2FOYjgkA==",
+        "requested": "[1.2.0-beta.435, )",
+        "resolved": "1.2.0-beta.435",
+        "contentHash": "TADk7vdGXtfTnYCV7GyleaaRTQjfoSfZXprQrVMm7cSJtJbFc1QIbWPyLvrgrfGdfHbGmUPvaN4ODKNxg2jgPQ==",
         "dependencies": {
-          "StyleCop.Analyzers.Unstable": "1.2.0.406"
+          "StyleCop.Analyzers.Unstable": "1.2.0.435"
         }
       },
       "System.Linq.Async": {
@@ -180,21 +180,21 @@
       },
       "Corvus.ContentHandling": {
         "type": "Transitive",
-        "resolved": "2.0.11",
-        "contentHash": "W4yuYfITGgwPg8KRFlLurwUp9aAsOggedBbtbLPPSmJTJzDK3BMiJnEJh/j0Rc2P37oqv3j8jhf3aOfvn7s5XQ==",
+        "resolved": "2.0.13",
+        "contentHash": "3c2989ocHqJmQDV/PRN0Oo55+/Zuiw5nz9BoBS66DgUeCM1oCE9SB7yuur4OCFiOZZG+P93yl4lg5lNOg/J64A==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.CSharp": "3.11.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.20",
+          "Microsoft.CodeAnalysis.CSharp": "4.3.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.28",
           "System.Runtime.Loader": "4.3.0"
         }
       },
       "Corvus.ContentHandling.Json": {
         "type": "Transitive",
-        "resolved": "2.0.11",
-        "contentHash": "aYnqiQB7nCe+Pq4szhsdBYRpaXcdZX0u77JL57YAKg/Jfty9p5xVB+9cwi+O7z6boD/xOyYjkr44qMvt06i/ng==",
+        "resolved": "2.0.13",
+        "contentHash": "y+3TerKbvASv+bDujKxs/gbpBcF8Weib7wpJPRD2jJosk8NEWa/IplGEhkO8yC2sX2hun1NlfMq/9KWQZXrJjg==",
         "dependencies": {
-          "Corvus.ContentHandling": "2.0.11",
-          "Corvus.Extensions.Newtonsoft.Json": "2.0.5",
+          "Corvus.ContentHandling": "2.0.13",
+          "Corvus.Extensions.Newtonsoft.Json": "2.0.6",
           "Newtonsoft.Json": "11.0.2"
         }
       },
@@ -222,11 +222,11 @@
       },
       "Corvus.Extensions.Newtonsoft.Json": {
         "type": "Transitive",
-        "resolved": "2.0.5",
-        "contentHash": "d9g6XjfyU5z2gffGNuOD4veWzCEUibioxvYyQkiwOmt+0SL5M0j4C6TNE6015LzEVYtnjLHXM+3op3NUqLtK7g==",
+        "resolved": "2.0.6",
+        "contentHash": "6yXJ7xbflSB3c0G7hdNExwlhbEChMRcSn6fX4k8ghhWyADrDSY6jJp9Ce6guxo1c4gVjZwgCVIDhA3JgO8KyHA==",
         "dependencies": {
-          "Corvus.Json.Abstractions": "2.0.5",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.18",
+          "Corvus.Json.Abstractions": "2.0.6",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.20",
           "Newtonsoft.Json": "11.0.2"
         }
       },
@@ -249,8 +249,8 @@
       },
       "Corvus.Json.Abstractions": {
         "type": "Transitive",
-        "resolved": "2.0.5",
-        "contentHash": "fUuuUwktUoCQNwR2+bvi2AcOPzJkU51o8Js37vCTdXBg4aDLQZaFIuyO9Dg9Sm9NW1hVhK5nBFkBaqbmF5rutg=="
+        "resolved": "2.0.6",
+        "contentHash": "ixx72ttlP/Ck+UMWyfiRWVBFKU5XjJySMG33ZWofJp9yy65VF3uOJyGPujr3OedUMo6Uq9umftmHRqhOmUyQ8g=="
       },
       "Corvus.Retry": {
         "type": "Transitive",
@@ -322,8 +322,8 @@
       },
       "Endjin.RecommendedPractices": {
         "type": "Transitive",
-        "resolved": "2.1.1",
-        "contentHash": "GfoEmy/55R7LmnBQbxIbYdGAxYfMaOQCTCOeVS9WKpPBA37YO/vuGMGd0OY8jaolKvsSd02V9jp2qdzQDX6CFw==",
+        "resolved": "2.1.2",
+        "contentHash": "Nbj0WS3zVDD2wjfU2/nbkWIWS9Ljg8VN+SSpaCuf5lHBOIEb0Ra201lGcyJHtRHybAciz+hQA9lHj7TnG52qqw==",
         "dependencies": {
           "Microsoft.Build.Tasks.Git": "1.1.1"
         }
@@ -478,29 +478,29 @@
       },
       "Microsoft.CodeAnalysis.Analyzers": {
         "type": "Transitive",
-        "resolved": "3.3.2",
-        "contentHash": "7xt6zTlIEizUgEsYAIgm37EbdkiMmr6fP6J9pDoKEpiGM4pi32BCPGr/IczmSJI9Zzp0a6HOzpr9OvpMP+2veA=="
+        "resolved": "3.3.3",
+        "contentHash": "j/rOZtLMVJjrfLRlAMckJLPW/1rze9MT1yfWqSIbUPGRu1m1P0fuo9PmqapwsmePfGB5PJrudQLvmUOAMF0DqQ=="
       },
       "Microsoft.CodeAnalysis.Common": {
         "type": "Transitive",
-        "resolved": "3.11.0",
-        "contentHash": "FDKSkRRXnaEWMa2ONkLMo0ZAt/uiV1XIXyodwKIgP1AMIKA7JJKXx/OwFVsvkkUT4BeobLwokoxFw70fICahNg==",
+        "resolved": "4.3.0",
+        "contentHash": "Hhaw6DKZHiR+vgOdIqvndfUntJhmDR7MjylUJ55EvWtDyJFLDf2eij8r9tcwXP35FLD+bVNNCO0+KIYuvJjNnA==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.Analyzers": "3.3.2",
-          "System.Collections.Immutable": "5.0.0",
+          "Microsoft.CodeAnalysis.Analyzers": "3.3.3",
+          "System.Collections.Immutable": "6.0.0",
           "System.Memory": "4.5.4",
           "System.Reflection.Metadata": "5.0.0",
-          "System.Runtime.CompilerServices.Unsafe": "5.0.0",
-          "System.Text.Encoding.CodePages": "4.5.1",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
+          "System.Text.Encoding.CodePages": "6.0.0",
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
       "Microsoft.CodeAnalysis.CSharp": {
         "type": "Transitive",
-        "resolved": "3.11.0",
-        "contentHash": "aDRRb7y/sXoJyDqFEQ3Il9jZxyUMHkShzZeCRjQf3SS84n2J0cTEi3TbwVZE9XJvAeMJhGfVVxwOdjYBg6ljmw==",
+        "resolved": "4.3.0",
+        "contentHash": "0PU4a2h7L6N9SlF/oNHwj2A/+n0LK/7n6PEGvXyIZq8hc7r/TztB+47mhVLvapT6bWSV7nMT78cNxbQuC6tk6g==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.Common": "[3.11.0]"
+          "Microsoft.CodeAnalysis.Common": "[4.3.0]"
         }
       },
       "Microsoft.CodeCoverage": {
@@ -1147,8 +1147,8 @@
       },
       "StyleCop.Analyzers.Unstable": {
         "type": "Transitive",
-        "resolved": "1.2.0.406",
-        "contentHash": "FclNdBR81ynIo9l1QNlo+l0I/PaFIYaPQPlMram8XVIMh6G6G43KTa1aCxfwTj13uKlAJS/LhLy6KjOPOeAU4w=="
+        "resolved": "1.2.0.435",
+        "contentHash": "ouwPWZxbOV3SmCZxIRqHvljkSzkCyi1tDoMzQtDb/bRP8ctASV/iRJr+A2Gdj0QLaLmWnqTWDrH82/iP+X80Lg=="
       },
       "System.AppContext": {
         "type": "Transitive",
@@ -1197,8 +1197,11 @@
       },
       "System.Collections.Immutable": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "FXkLXiK0sVVewcso0imKQoOxjoPAj42R8HtjjbSjVPAzwDfzoyoznWxgA3c38LDbN9SJux1xXoXYAhz98j7r2g=="
+        "resolved": "6.0.0",
+        "contentHash": "l4zZJ1WU2hqpQQHXz1rvC3etVZN+2DLmQMO79FhOTZHMn8tDRr+WU287sbomD0BETlmKDn0ygUgVy9k5xkkJdA==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
       },
       "System.Collections.NonGeneric": {
         "type": "Transitive",
@@ -2214,10 +2217,10 @@
       },
       "System.Text.Encoding.CodePages": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "NyscU59xX6Uo91qvhOs2Ccho3AR2TnZPomo1Z0K6YpyztBPM/A5VbkzOO19sy3A3i1TtEnTxA7bCe3Us+r5MWg==",
+        "resolved": "6.0.0",
+        "contentHash": "ZFCILZuOvtKPauZ/j/swhvw68ZRi9ATCfvGbk1QfydmcXBkIWecWKn/250UH7rahZ5OoDBaiAudJtPvLwzw85A==",
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "5.0.0"
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
       },
       "System.Text.Encoding.Extensions": {
@@ -2499,7 +2502,7 @@
       "corvus.tenancy.abstractions": {
         "type": "Project",
         "dependencies": {
-          "Corvus.ContentHandling.Json": "[2.0.11, )",
+          "Corvus.ContentHandling.Json": "[2.0.13, )",
           "Corvus.Extensions": "[1.1.4, )",
           "Microsoft.Extensions.Primitives": "[6.0.*, )"
         }

--- a/docs/ReleaseNotes/Corvus.Tenancy.v3.md
+++ b/docs/ReleaseNotes/Corvus.Tenancy.v3.md
@@ -1,5 +1,9 @@
 # Release notes for Corvus.Tenancy v3.
 
+## v3.3
+
+Enables tenanted container and table names (logical or, where applicable, hashed) to be obtained for a tenant ID (instead of being required to pass an `ITenant`).
+
 ## v3.2
 
 Adds support for Azure Tables.


### PR DESCRIPTION
Closes #429 

Before this, we required an ITenant, even though the only thing we did with it was retrieve the id.