### PR TITLE
Migrate from Newtonsoft.Json to System.Text.Json

### DIFF
--- a/Solutions/Corvus.Azure.Storage.Tenancy/Microsoft/Extensions/DependencyInjection/TenancyBlobStorageServiceCollectionExtensions.cs
+++ b/Solutions/Corvus.Azure.Storage.Tenancy/Microsoft/Extensions/DependencyInjection/TenancyBlobStorageServiceCollectionExtensions.cs
@@ -8,8 +8,6 @@ namespace Microsoft.Extensions.DependencyInjection
 
     using Corvus.Azure.Storage.Tenancy;
     using Corvus.Tenancy.Internal;
-    using Newtonsoft.Json;
-    using Newtonsoft.Json.Converters;
 
     /// <summary>
     /// Common configuration code for services with stores implemented on top of tenanted
@@ -44,10 +42,10 @@ namespace Microsoft.Extensions.DependencyInjection
             ArgumentNullException.ThrowIfNull(getOptions);
 
             services.AddRequiredTenancyServices();
-            services.AddJsonNetSerializerSettingsProvider();
-            services.AddJsonNetPropertyBag();
-            services.AddJsonNetCultureInfoConverter();
-            services.AddJsonNetDateTimeOffsetToIso8601AndUnixTimeConverter();
+            services.AddJsonSerializerOptionsProvider();
+            services.AddJsonPropertyBagFactory();
+            services.AddJsonCultureInfoConverter();
+            services.AddJsonDateTimeOffsetToIso8601AndUnixTimeConverter();
 
             services.AddSingleton<ITenantCloudBlobContainerFactory>(s =>
             {

--- a/Solutions/Corvus.Tenancy.Abstractions/Corvus.Tenancy.Abstractions.csproj
+++ b/Solutions/Corvus.Tenancy.Abstractions/Corvus.Tenancy.Abstractions.csproj
@@ -17,9 +17,9 @@
   <ItemGroup>
     <PackageReference Include="Corvus.ContentHandling" Version="4.0.0" />
     <PackageReference Include="Corvus.ContentHandling.Json" Version="4.0.0" />
-    <PackageReference Include="Corvus.Extensions.Newtonsoft.Json" Version="3.0.2" />
     <PackageReference Include="Corvus.Extensions" Version="1.1.13" />
     <PackageReference Include="Corvus.Json.Abstractions" Version="3.0.2" />
+    <PackageReference Include="Corvus.Json.PropertyBag" Version="2.0.0" />
     <PackageReference Include="Endjin.RecommendedPractices.GitHub" Version="2.1.18">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Solutions/Corvus.Tenancy.Abstractions/Corvus/Tenancy/Internal/TenantServiceCollectionExtensions.cs
+++ b/Solutions/Corvus.Tenancy.Abstractions/Corvus/Tenancy/Internal/TenantServiceCollectionExtensions.cs
@@ -20,8 +20,8 @@ namespace Corvus.Tenancy.Internal
         /// <returns>The configured service collection.</returns>
         public static IServiceCollection AddRequiredTenancyServices(this IServiceCollection services)
         {
-            services.AddJsonNetSerializerSettingsProvider();
-            services.AddJsonNetPropertyBag();
+            services.AddJsonSerializerOptionsProvider();
+            services.AddJsonPropertyBagFactory();
             services.AddContentTypeBasedSerializationSupport();
 
             _ = services.AddContent(

--- a/Solutions/Corvus.Tenancy.Specs/packages.lock.json
+++ b/Solutions/Corvus.Tenancy.Specs/packages.lock.json
@@ -186,6 +186,16 @@
         "resolved": "3.0.2",
         "contentHash": "i3HErZbnQsYwUgS9sA+sQYpVX0r5ETmBSApy13wC5hVqEvI/YVXBztoLMmkEOaJEo1c16H8JT2s+j/hDGqSz6g=="
       },
+      "Corvus.Json.PropertyBag": {
+        "type": "Transitive",
+        "resolved": "2.0.0",
+        "contentHash": "BOqpruU6YOktu8YURl5sPJz1sF9LL8s12k9pPWQubHd1Ie+Rq8S4uiBYVpAh2gJPBVgeJviMGx60EaMQ3ybgcg==",
+        "dependencies": {
+          "Corvus.Json.Abstractions": "3.0.0",
+          "Corvus.Json.Serialization": "2.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2"
+        }
+      },
       "Corvus.Json.Serialization": {
         "type": "Transitive",
         "resolved": "2.0.0",
@@ -1941,8 +1951,8 @@
           "Corvus.ContentHandling": "[4.0.0, )",
           "Corvus.ContentHandling.Json": "[4.0.0, )",
           "Corvus.Extensions": "[1.1.13, )",
-          "Corvus.Extensions.Newtonsoft.Json": "[3.0.2, )",
           "Corvus.Json.Abstractions": "[3.0.2, )",
+          "Corvus.Json.PropertyBag": "[2.0.0, )",
           "Microsoft.Extensions.Primitives": "[8.0.*, )"
         }
       },

--- a/Solutions/Corvus.Tenancy.Storage.Azure.Blob/Corvus.Tenancy.Storage.Azure.Blob.csproj
+++ b/Solutions/Corvus.Tenancy.Storage.Azure.Blob/Corvus.Tenancy.Storage.Azure.Blob.csproj
@@ -25,6 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    
     <PackageReference Include="Corvus.Json.Abstractions" Version="3.0.2" />
     <PackageReference Include="Endjin.RecommendedPractices.GitHub" Version="2.1.18">
       <PrivateAssets>all</PrivateAssets>

--- a/Solutions/Corvus.Tenancy.Storage.Azure.Blob/Microsoft/Extensions/DependencyInjection/TenantProviderBlobStoreServiceCollectionExtensions.cs
+++ b/Solutions/Corvus.Tenancy.Storage.Azure.Blob/Microsoft/Extensions/DependencyInjection/TenantProviderBlobStoreServiceCollectionExtensions.cs
@@ -6,9 +6,10 @@ namespace Microsoft.Extensions.DependencyInjection
 {
     using System;
     using System.Linq;
+
     using Corvus.Azure.Storage.Tenancy;
-    using Corvus.Extensions.Json;
     using Corvus.Json;
+    using Corvus.Json.Serialization;
     using Corvus.Tenancy;
     using Corvus.Tenancy.Internal;
 
@@ -50,7 +51,7 @@ namespace Microsoft.Extensions.DependencyInjection
                         TenantProviderBlobStore.ContainerDefinition, rootTenantStorageConfig));
 
                 ITenantCloudBlobContainerFactory tenantCloudBlobContainerFactory = sp.GetRequiredService<ITenantCloudBlobContainerFactory>();
-                IJsonSerializerSettingsProvider serializerSettingsProvider = sp.GetRequiredService<IJsonSerializerSettingsProvider>();
+                IJsonSerializerOptionsProvider serializerSettingsProvider = sp.GetRequiredService<IJsonSerializerOptionsProvider>();
 
                 return new TenantProviderBlobStore(rootTenant, propertyBagFactory, tenantCloudBlobContainerFactory, serializerSettingsProvider);
             });


### PR DESCRIPTION
This commit updates the codebase to use System.Text.Json for JSON serialization and deserialization. It includes changes to method calls, new service registrations, and the removal of Newtonsoft.Json package references. Additionally, new packages for Corvus.Json.PropertyBag have been added, and service collection extensions have been updated to utilize the new JSON options provider and property bag factory.